### PR TITLE
Add swipe-to-dismiss gesture for mobile verse drawer

### DIFF
--- a/components/Reader/index.tsx
+++ b/components/Reader/index.tsx
@@ -337,8 +337,7 @@ function Reader({
 											? styles.reading
 											: ""
 									}`}
-									onPointerUp={(e) => {
-										e.preventDefault();
+									onClick={() => {
 										handleVerseClick(chapter.chapter, verse.verse, verse.text);
 									}}
 								>

--- a/components/VerseDetails/VerseDetails.module.css
+++ b/components/VerseDetails/VerseDetails.module.css
@@ -1,10 +1,44 @@
+.drawerWrapper {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	touch-action: pan-y;
+}
+
+.dragHandle {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	padding: 12px 0 8px;
+	cursor: grab;
+	touch-action: none;
+}
+
+.dragHandle:active {
+	cursor: grabbing;
+}
+
+.dragIndicator {
+	width: 36px;
+	height: 4px;
+	background: rgba(0, 0, 0, 0.2);
+	border-radius: 2px;
+}
+
 .header {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	padding-bottom: 20px;
+	padding: 0 24px 20px;
 	margin-bottom: 20px;
 	border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+/* When there's no drag handle (desktop), add top padding */
+@media (min-width: 821px) {
+	.header {
+		padding-top: 24px;
+	}
 }
 
 .reference {

--- a/components/VerseDetails/index.tsx
+++ b/components/VerseDetails/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { Drawer } from "@mantine/core";
 import styles from "./VerseDetails.module.css";
 import {
@@ -36,7 +36,62 @@ export default function VerseDetails({
 	const [isBookmarked, setIsBookmarked] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
 
+	// Swipe-to-dismiss state
+	const [dragY, setDragY] = useState(0);
+	const [isDragging, setIsDragging] = useState(false);
+	const dragStartY = useRef(0);
+	const drawerContentRef = useRef<HTMLDivElement>(null);
+
 	console.log("VerseDetails rendered:", { active, book, chapter, verse });
+
+	// Reset drag state when drawer closes
+	useEffect(() => {
+		if (!active) {
+			setDragY(0);
+			setIsDragging(false);
+		}
+	}, [active]);
+
+	// Swipe gesture handlers
+	const handleTouchStart = useCallback((e: React.TouchEvent) => {
+		// Only allow drag from the handle area or if at top of scroll
+		const target = e.target as HTMLElement;
+		const isHandle = target.closest(`.${styles.dragHandle}`);
+		const contentEl = drawerContentRef.current?.querySelector(`.${styles.content}`) as HTMLElement;
+		const isAtTop = !contentEl || contentEl.scrollTop === 0;
+
+		if (isHandle || isAtTop) {
+			dragStartY.current = e.touches[0].clientY;
+			setIsDragging(true);
+		}
+	}, []);
+
+	const handleTouchMove = useCallback((e: React.TouchEvent) => {
+		if (!isDragging) return;
+
+		const currentY = e.touches[0].clientY;
+		const deltaY = currentY - dragStartY.current;
+
+		// Only allow dragging downward (positive deltaY)
+		if (deltaY > 0) {
+			setDragY(deltaY);
+		}
+	}, [isDragging]);
+
+	const handleTouchEnd = useCallback(() => {
+		if (!isDragging) return;
+
+		// If dragged more than 100px or 20% of viewport height, close the drawer
+		const threshold = Math.min(100, window.innerHeight * 0.2);
+
+		if (dragY > threshold) {
+			onClose();
+		}
+
+		// Reset drag state
+		setDragY(0);
+		setIsDragging(false);
+	}, [isDragging, dragY, onClose]);
 
 	useEffect(() => {
 		console.log("VerseDetails useEffect:", { active, book, chapter, verse });
@@ -119,75 +174,103 @@ export default function VerseDetails({
 
 	const isMobile = typeof window !== "undefined" && window.innerWidth <= 820;
 
+	// Swipe styles for mobile bottom drawer
+	const swipeStyle = isMobile && dragY > 0 ? {
+		transform: `translateY(${dragY}px)`,
+		transition: isDragging ? 'none' : 'transform 0.3s ease-out',
+	} : {
+		transition: isDragging ? 'none' : 'transform 0.3s ease-out',
+	};
+
 	return (
 		<Drawer
 			opened={active}
 			onClose={onClose}
 			position={isMobile ? "bottom" : "right"}
 			size={isMobile ? "70vh" : "md"}
-			padding="lg"
+			padding={0}
 			withCloseButton={false}
+			styles={isMobile ? {
+				content: {
+					...swipeStyle,
+				},
+			} : undefined}
 		>
-			<div className={styles.header}>
-				<h3 className={styles.reference}>
-					{book} {chapter}:{verse}
-				</h3>
-				<button
-					className={styles.closeButton}
-					onPointerUp={(e) => {
-						e.preventDefault();
-						onClose();
-					}}
-					aria-label="Close"
-				>
-					<IconX size={24} />
-				</button>
-			</div>
+			<div
+				ref={drawerContentRef}
+				onTouchStart={isMobile ? handleTouchStart : undefined}
+				onTouchMove={isMobile ? handleTouchMove : undefined}
+				onTouchEnd={isMobile ? handleTouchEnd : undefined}
+				className={styles.drawerWrapper}
+			>
+				{/* Drag handle for mobile */}
+				{isMobile && (
+					<div className={styles.dragHandle}>
+						<div className={styles.dragIndicator} />
+					</div>
+				)}
 
-			<div className={styles.content}>
-				<p className={styles.verseText}>{text}</p>
-			</div>
+				<div className={styles.header}>
+					<h3 className={styles.reference}>
+						{book} {chapter}:{verse}
+					</h3>
+					<button
+						className={styles.closeButton}
+						onPointerUp={(e) => {
+							e.preventDefault();
+							onClose();
+						}}
+						aria-label="Close"
+					>
+						<IconX size={24} />
+					</button>
+				</div>
 
-			<div className={styles.actions}>
-				<button
-					className={styles.actionButton}
-					onPointerUp={(e) => {
-						e.preventDefault();
-						handleBookmarkToggle();
-					}}
-					disabled={isLoading}
-				>
-					{isBookmarked ? (
-						<IconBookmarkFilled size={24} />
-					) : (
-						<IconBookmark size={24} />
-					)}
-					<span>{isBookmarked ? "Bookmarked" : "Bookmark"}</span>
-				</button>
+				<div className={styles.content}>
+					<p className={styles.verseText}>{text}</p>
+				</div>
 
-				{onPlayAudio && (
+				<div className={styles.actions}>
 					<button
 						className={styles.actionButton}
 						onPointerUp={(e) => {
 							e.preventDefault();
-							onPlayAudio(parseInt(chapter), parseInt(verse));
+							handleBookmarkToggle();
+						}}
+						disabled={isLoading}
+					>
+						{isBookmarked ? (
+							<IconBookmarkFilled size={24} />
+						) : (
+							<IconBookmark size={24} />
+						)}
+						<span>{isBookmarked ? "Bookmarked" : "Bookmark"}</span>
+					</button>
+
+					{onPlayAudio && (
+						<button
+							className={styles.actionButton}
+							onPointerUp={(e) => {
+								e.preventDefault();
+								onPlayAudio(parseInt(chapter), parseInt(verse));
+							}}
+						>
+							<IconPlayerPlay size={24} />
+							<span>Play</span>
+						</button>
+					)}
+
+					<button
+						className={styles.actionButton}
+						onPointerUp={(e) => {
+							e.preventDefault();
+							handleShare();
 						}}
 					>
-						<IconPlayerPlay size={24} />
-						<span>Play</span>
+						<IconShare size={24} />
+						<span>Share</span>
 					</button>
-				)}
-
-				<button
-					className={styles.actionButton}
-					onPointerUp={(e) => {
-						e.preventDefault();
-						handleShare();
-					}}
-				>
-					<IconShare size={24} />
-					<span>Share</span>
-				</button>
+				</div>
 			</div>
 		</Drawer>
 	);

--- a/components/VerseDetails/index.tsx
+++ b/components/VerseDetails/index.tsx
@@ -174,13 +174,11 @@ export default function VerseDetails({
 
 	const isMobile = typeof window !== "undefined" && window.innerWidth <= 820;
 
-	// Swipe styles for mobile bottom drawer
-	const swipeStyle = isMobile && dragY > 0 ? {
-		transform: `translateY(${dragY}px)`,
+	// Swipe styles for mobile bottom drawer - applied to wrapper div
+	const wrapperStyle: React.CSSProperties = isMobile ? {
+		transform: dragY > 0 ? `translateY(${dragY}px)` : undefined,
 		transition: isDragging ? 'none' : 'transform 0.3s ease-out',
-	} : {
-		transition: isDragging ? 'none' : 'transform 0.3s ease-out',
-	};
+	} : {};
 
 	return (
 		<Drawer
@@ -190,11 +188,6 @@ export default function VerseDetails({
 			size={isMobile ? "70vh" : "md"}
 			padding={0}
 			withCloseButton={false}
-			styles={isMobile ? {
-				content: {
-					...swipeStyle,
-				},
-			} : undefined}
 		>
 			<div
 				ref={drawerContentRef}
@@ -202,6 +195,7 @@ export default function VerseDetails({
 				onTouchMove={isMobile ? handleTouchMove : undefined}
 				onTouchEnd={isMobile ? handleTouchEnd : undefined}
 				className={styles.drawerWrapper}
+				style={wrapperStyle}
 			>
 				{/* Drag handle for mobile */}
 				{isMobile && (


### PR DESCRIPTION
On mobile, the bottom drawer now includes a drag handle indicator and
can be dismissed by swiping down. The drawer moves with the finger and
closes when dragged past the threshold (100px or 20% of viewport).

https://claude.ai/code/session_01GrNgTVZh1PwX5C4z44Ldcv