### PR TITLE
Add verse notes feature with persistent storage

### DIFF
--- a/components/VerseDetails/VerseDetails.module.css
+++ b/components/VerseDetails/VerseDetails.module.css
@@ -44,6 +44,43 @@
 	font-family: var(--serif), georgia, serif;
 }
 
+.notesSection {
+	margin-top: 24px;
+}
+
+.notesLabel {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 13px;
+	font-weight: 500;
+	opacity: 0.6;
+	margin-bottom: 8px;
+}
+
+.noteTextarea {
+	width: 100%;
+	padding: 12px;
+	font-size: 15px;
+	line-height: 1.5;
+	font-family: var(--serif), georgia, serif;
+	background: rgba(0, 0, 0, 0.03);
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	border-radius: 8px;
+	resize: vertical;
+	outline: none;
+	transition: border-color 0.2s;
+	box-sizing: border-box;
+}
+
+.noteTextarea:focus {
+	border-color: rgba(0, 0, 0, 0.3);
+}
+
+.noteTextarea::placeholder {
+	opacity: 0.4;
+}
+
 .actions {
 	display: flex;
 	gap: 12px;

--- a/types/bible.ts
+++ b/types/bible.ts
@@ -57,6 +57,16 @@ export interface Bookmark {
 	note?: string;
 }
 
+export interface VerseNote {
+	id: string;
+	book: string;
+	chapter: string;
+	verse: string;
+	content: string;
+	createdAt: number;
+	updatedAt: number;
+}
+
 // Component Props Types
 export interface MainProps {
 	slug?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -423,6 +423,11 @@
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz"
   integrity sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==
 
+"@rollup/rollup-linux-x64-musl@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz"
+  integrity sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==
+
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz"


### PR DESCRIPTION
## Summary
This PR adds a complete verse notes feature that allows users to create, read, update, and delete notes attached to specific Bible verses. Notes are persisted in IndexedDB and automatically saved when the user closes the verse details drawer.

## Key Changes

- **Database Schema**: Upgraded BibleStorage database version from 2 to 3, adding a new "notes" object store with indexes for efficient querying by verse reference, creation time, and update time

- **Storage Methods**: Implemented four new methods in BibleStorage:
  - `addNote()` - Creates a new note for a verse with auto-generated UUID and timestamps
  - `updateNote()` - Updates note content and refreshes the updatedAt timestamp
  - `deleteNote()` - Removes a note from storage
  - `getNotesForVerse()` - Retrieves all notes for a specific verse, sorted by most recently updated first

- **UI Component**: Enhanced VerseDetails drawer with:
  - A notes section with textarea input below the verse text
  - Auto-save functionality that triggers on blur and when closing the drawer
  - Loads existing notes when a verse is opened
  - Deletes notes when content is cleared

- **Type Definition**: Added `VerseNote` interface to the bible types with fields for id, verse reference (book/chapter/verse), content, and timestamps

- **Styling**: Added CSS for the notes section including textarea styling with focus states and placeholder text

## Implementation Details

- Notes are automatically saved when the textarea loses focus (onBlur) or when the drawer closes
- The component uses a ref to track the last saved note content to avoid unnecessary database operations
- Multiple notes can exist for the same verse, displayed in reverse chronological order by update time
- The clearAll() method was updated to include the notes store in its cleanup routine
- Comprehensive test coverage added for all note operations

https://claude.ai/code/session_01VcpZW1h31xrUi7kDNegp14