### PR TITLE
Improve service worker update strategy with network-first navigation

### DIFF
--- a/app/ServiceWorkerProvider.tsx
+++ b/app/ServiceWorkerProvider.tsx
@@ -52,15 +52,6 @@ export default function ServiceWorkerProvider({
 						console.log("SW registration failed: ", registrationError);
 					});
 			});
-
-			// When a new service worker takes control, reload to get fresh content
-			let refreshing = false;
-			navigator.serviceWorker.addEventListener("controllerchange", () => {
-				if (!refreshing) {
-					refreshing = true;
-					window.location.reload();
-				}
-			});
 		}
 	}, []);
 


### PR DESCRIPTION
## Summary
This PR enhances the service worker caching strategy to ensure users receive the latest UI updates promptly while maintaining offline functionality. It implements a network-first approach for HTML navigation requests and adds automatic activation of new service worker versions.

## Key Changes

- **Updated cache version**: Bumped `CACHE_NAME` from "bible-reader-v1" to "bible-reader-v2" to invalidate old caches
- **Network-first strategy for navigation**: Added dedicated handling for navigation requests (HTML pages) that prioritizes fetching from the network while falling back to cached versions when offline
- **Automatic service worker activation**: Modified `ServiceWorkerProvider` to immediately activate new service worker versions by:
  - Posting `SKIP_WAITING` message to waiting workers upon registration
  - Listening for new installations and activating them immediately when a controller is present
- **Improved static asset caching**: Clarified that GET requests use cache-first strategy, with a note that Next.js content-hashed filenames ensure cached versions remain valid

## Implementation Details

The network-first strategy for navigation requests ensures that:
- Users always get the latest HTML/UI after an update
- The latest version is cached for offline use
- A user-friendly offline message is shown if the page isn't cached
- The service worker doesn't need to be manually refreshed by users

The automatic activation mechanism eliminates the need for users to manually refresh their browser to get new service worker updates, providing a seamless update experience.

https://claude.ai/code/session_01TvAh7fKXhv7eb1XtbTxqE8