### PR TITLE
Add offline Bible search with IndexedDB seeding and inverted index

### DIFF
--- a/components/Main/index.tsx
+++ b/components/Main/index.tsx
@@ -17,6 +17,7 @@ import { Books } from "../../utils/Books";
 import { useReadingPosition } from "../../utils/useReadingPosition";
 import { useAudioPlayer } from "../../utils/useAudioPlayer";
 import { scrollToVerse } from "../../utils/scrollToVerse";
+import { useBibleSeed } from "../../utils/useBibleSeed";
 
 export default function Main({ slug, book }: MainProps) {
 	const [bookNavVisible, setBookNavVisible] = useState<boolean>(false);
@@ -36,6 +37,9 @@ export default function Main({ slug, book }: MainProps) {
 	} | null>(null);
 
 	const dismissSearch = useCallback(() => setSearchVisible(false), []);
+
+	// Seed the full Bible into IndexedDB in the background for offline support & fast search
+	const seedProgress = useBibleSeed();
 
 	const {
 		currentPosition,
@@ -208,6 +212,7 @@ export default function Main({ slug, book }: MainProps) {
 				dismiss={dismissSearch}
 				active={searchVisible}
 				currentBook={currentBook}
+				isIndexReady={seedProgress.status === "done"}
 			/>
 
 			<Bookmarks

--- a/types/bible.ts
+++ b/types/bible.ts
@@ -47,6 +47,20 @@ export interface BibleContent {
 	lastCached: number;
 }
 
+export interface VerseRecord {
+	id: string; // "Genesis-1:1"
+	book: string;
+	bookIndex: number;
+	chapter: string;
+	verse: string;
+	text: string;
+}
+
+export interface SearchIndexEntry {
+	word: string;
+	refs: string[]; // verse IDs
+}
+
 export interface Bookmark {
 	id: string;
 	book: string;

--- a/utils/seedBibleData.test.ts
+++ b/utils/seedBibleData.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import { IDBFactory } from 'fake-indexeddb';
+import type { Book } from '../types/bible';
+
+let seedBibleData: typeof import('./seedBibleData').seedBibleData;
+let isSeedingNeeded: typeof import('./seedBibleData').isSeedingNeeded;
+let BibleStorage: typeof import('./BibleStorage').default;
+
+const mockBooks: Book[] = [
+  {
+    book: 'Genesis',
+    index: 0,
+    chapters: [
+      {
+        chapter: '1',
+        verses: [
+          { verse: '1', text: 'In the beginning God created the heaven and the earth.' },
+          { verse: '2', text: 'And the earth was without form, and void.' },
+          { verse: '3', text: 'And God said, Let there be light: and there was light.' },
+        ],
+      },
+      {
+        chapter: '2',
+        verses: [
+          { verse: '1', text: 'Thus the heavens and the earth were finished.' },
+        ],
+      },
+    ],
+  },
+  {
+    book: 'John',
+    index: 42,
+    chapters: [
+      {
+        chapter: '1',
+        verses: [
+          { verse: '1', text: 'In the beginning was the Word, and the Word was with God.' },
+        ],
+      },
+    ],
+  },
+];
+
+describe('seedBibleData', () => {
+  beforeEach(async () => {
+    globalThis.indexedDB = new IDBFactory();
+    vi.resetModules();
+
+    const storageModule = await import('./BibleStorage');
+    BibleStorage = storageModule.default;
+
+    const seedModule = await import('./seedBibleData');
+    seedBibleData = seedModule.seedBibleData;
+    isSeedingNeeded = seedModule.isSeedingNeeded;
+  });
+
+  describe('isSeedingNeeded()', () => {
+    it('should return true when no seed version is stored', async () => {
+      const needed = await isSeedingNeeded();
+      expect(needed).toBe(true);
+    });
+
+    it('should return false after seeding completes', async () => {
+      await seedBibleData(mockBooks);
+
+      const needed = await isSeedingNeeded();
+      expect(needed).toBe(false);
+    });
+  });
+
+  describe('seedBibleData()', () => {
+    it('should seed all verses into IndexedDB', async () => {
+      await seedBibleData(mockBooks);
+
+      const count = await BibleStorage.getVerseCount();
+      // 3 verses in Genesis ch1 + 1 in Genesis ch2 + 1 in John ch1 = 5
+      expect(count).toBe(5);
+    });
+
+    it('should store verses with correct structure', async () => {
+      await seedBibleData(mockBooks);
+
+      const verses = await BibleStorage.getVersesByIds(['Genesis-1:1']);
+      expect(verses).toHaveLength(1);
+      expect(verses[0]).toEqual({
+        id: 'Genesis-1:1',
+        book: 'Genesis',
+        bookIndex: 0,
+        chapter: '1',
+        verse: '1',
+        text: 'In the beginning God created the heaven and the earth.',
+      });
+    });
+
+    it('should build a search index', async () => {
+      await seedBibleData(mockBooks);
+
+      const entry = await BibleStorage.getSearchIndexEntry('beginning');
+      expect(entry).not.toBeNull();
+      // "beginning" appears in Genesis 1:1 and John 1:1
+      expect(entry!.refs).toContain('Genesis-1:1');
+      expect(entry!.refs).toContain('John-1:1');
+    });
+
+    it('should index words case-insensitively', async () => {
+      await seedBibleData(mockBooks);
+
+      // "God" appears as "god" in the index
+      const entry = await BibleStorage.getSearchIndexEntry('god');
+      expect(entry).not.toBeNull();
+      expect(entry!.refs.length).toBeGreaterThan(0);
+    });
+
+    it('should not index single-character words', async () => {
+      await seedBibleData(mockBooks);
+
+      // Single-char words like "a" should not be indexed
+      const entry = await BibleStorage.getSearchIndexEntry('a');
+      expect(entry).toBeNull();
+    });
+
+    it('should call progress callback', async () => {
+      const onProgress = vi.fn();
+      await seedBibleData(mockBooks, onProgress);
+
+      // Should have been called at least twice: seeding + done
+      expect(onProgress).toHaveBeenCalled();
+
+      // Last call should be "done"
+      const lastCall = onProgress.mock.calls[onProgress.mock.calls.length - 1][0];
+      expect(lastCall.status).toBe('done');
+      expect(lastCall.booksProcessed).toBe(mockBooks.length);
+      expect(lastCall.totalBooks).toBe(mockBooks.length);
+    });
+
+    it('should set seed version preference after completion', async () => {
+      await seedBibleData(mockBooks);
+
+      const version = await BibleStorage.getPreference('seedVersion');
+      expect(version).toBe(1);
+    });
+
+    it('should skip seeding on subsequent calls if version matches', async () => {
+      await seedBibleData(mockBooks);
+
+      const needed = await isSeedingNeeded();
+      expect(needed).toBe(false);
+    });
+  });
+});

--- a/utils/seedBibleData.ts
+++ b/utils/seedBibleData.ts
@@ -1,0 +1,131 @@
+import type { Book, VerseRecord, SearchIndexEntry } from "../types/bible";
+import BibleStorage from "./BibleStorage";
+
+// Seed version — bump this to force a re-seed when the data/schema changes
+const SEED_VERSION = 1;
+
+// How many books to process per chunk before yielding to the browser
+const BOOKS_PER_CHUNK = 3;
+
+export type SeedStatus = "idle" | "seeding" | "done" | "error";
+
+export interface SeedProgress {
+	status: SeedStatus;
+	booksProcessed: number;
+	totalBooks: number;
+}
+
+type ProgressCallback = (progress: SeedProgress) => void;
+
+/**
+ * Tokenize verse text into lowercase words, stripping punctuation.
+ * Returns unique words for a given text.
+ */
+function tokenize(text: string): string[] {
+	return text
+		.toLowerCase()
+		.replace(/[^a-z0-9' ]/g, " ")
+		.split(/\s+/)
+		.filter((w) => w.length > 1);
+}
+
+/**
+ * Check whether seeding is needed by comparing the stored seed version.
+ */
+export async function isSeedingNeeded(): Promise<boolean> {
+	try {
+		const storedVersion = await BibleStorage.getPreference("seedVersion", null);
+		return storedVersion !== SEED_VERSION;
+	} catch {
+		return true;
+	}
+}
+
+/**
+ * Yield to the browser event loop so the UI stays responsive.
+ */
+function yieldToBrowser(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Seed the entire Bible into IndexedDB:
+ *  1. Writes all verses into the `verses` store
+ *  2. Builds an inverted index (word → verse IDs) in the `searchIndex` store
+ *  3. Saves a seed version flag so we skip on subsequent loads
+ *
+ * Books are processed in small chunks with yielding to keep the UI responsive.
+ */
+export async function seedBibleData(
+	books: Book[],
+	onProgress?: ProgressCallback
+): Promise<void> {
+	const totalBooks = books.length;
+	const invertedIndex = new Map<string, string[]>();
+
+	const report = (status: SeedStatus, booksProcessed: number) => {
+		onProgress?.({ status, booksProcessed, totalBooks });
+	};
+
+	report("seeding", 0);
+
+	// Process books in chunks
+	for (let i = 0; i < totalBooks; i += BOOKS_PER_CHUNK) {
+		const chunk = books.slice(i, i + BOOKS_PER_CHUNK);
+		const verses: VerseRecord[] = [];
+
+		for (const book of chunk) {
+			for (const chapter of book.chapters) {
+				for (const verse of chapter.verses) {
+					const id = `${book.book}-${chapter.chapter}:${verse.verse}`;
+					verses.push({
+						id,
+						book: book.book,
+						bookIndex: book.index,
+						chapter: chapter.chapter,
+						verse: verse.verse,
+						text: verse.text,
+					});
+
+					// Build inverted index entries
+					const words = tokenize(verse.text);
+					for (const word of words) {
+						let refs = invertedIndex.get(word);
+						if (!refs) {
+							refs = [];
+							invertedIndex.set(word, refs);
+						}
+						refs.push(id);
+					}
+				}
+			}
+		}
+
+		// Write this chunk of verses to IndexedDB
+		await BibleStorage.putVerses(verses);
+
+		report("seeding", Math.min(i + BOOKS_PER_CHUNK, totalBooks));
+
+		// Yield between chunks so the UI stays responsive
+		await yieldToBrowser();
+	}
+
+	// Write the inverted index in batches
+	const indexEntries: SearchIndexEntry[] = [];
+	for (const [word, refs] of invertedIndex) {
+		indexEntries.push({ word, refs });
+	}
+
+	// Write index entries in batches of 500
+	const INDEX_BATCH_SIZE = 500;
+	for (let i = 0; i < indexEntries.length; i += INDEX_BATCH_SIZE) {
+		const batch = indexEntries.slice(i, i + INDEX_BATCH_SIZE);
+		await BibleStorage.putSearchIndexEntries(batch);
+		await yieldToBrowser();
+	}
+
+	// Mark seeding as complete
+	await BibleStorage.savePreference("seedVersion", SEED_VERSION);
+
+	report("done", totalBooks);
+}

--- a/utils/useBibleSeed.ts
+++ b/utils/useBibleSeed.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import type { SeedProgress } from "./seedBibleData";
+
+/**
+ * Hook that triggers background seeding of the entire Bible into IndexedDB.
+ *
+ * On first load (or after a seed version bump), this seeds all verses and
+ * builds an inverted search index. Subsequent loads skip seeding entirely.
+ *
+ * Returns the current seeding status so consumers can react when the
+ * index becomes available (e.g., switch search to indexed mode).
+ */
+export function useBibleSeed(): SeedProgress {
+	const [progress, setProgress] = useState<SeedProgress>({
+		status: "idle",
+		booksProcessed: 0,
+		totalBooks: 0,
+	});
+	const started = useRef(false);
+
+	useEffect(() => {
+		if (started.current) return;
+		started.current = true;
+
+		(async () => {
+			const { isSeedingNeeded, seedBibleData } = await import("./seedBibleData");
+
+			const needed = await isSeedingNeeded();
+			if (!needed) {
+				setProgress({ status: "done", booksProcessed: 66, totalBooks: 66 });
+				return;
+			}
+
+			// Dynamically import the full Books array — this is already
+			// bundled in the JS, so no network request happens here
+			const { Books } = await import("./Books");
+
+			try {
+				await seedBibleData(Books, (p) => setProgress(p));
+			} catch (err) {
+				console.error("Bible seeding failed:", err);
+				setProgress((prev) => ({ ...prev, status: "error" }));
+			}
+		})();
+	}, []);
+
+	return progress;
+}


### PR DESCRIPTION
## Summary
This PR implements offline Bible search capabilities by seeding the entire Bible into IndexedDB on first load and building an inverted search index for fast, efficient keyword lookups. The search component now uses indexed search when available, with automatic fallback to brute-force search during initial seeding.

## Key Changes

- **Bible Seeding System** (`seedBibleData.ts`): New module that seeds all 66 books into IndexedDB in chunked batches with progress reporting. Includes tokenization logic for building an inverted word→verse index, with configurable seed versioning to force re-seeding when data changes.

- **Indexed Search** (`Search` component): Implements `indexedSearch()` function that performs multi-keyword intersection queries against the inverted index, then fetches and filters matching verses. Automatically switches to indexed search when seeding completes.

- **Storage Layer** (`BibleStorage.ts`): 
  - Added two new object stores: `verses` (individual verse records) and `searchIndex` (inverted index)
  - New methods: `putVerses()`, `putSearchIndexEntries()`, `getSearchIndexEntry()`, `getVersesByIds()`, `getVerseCount()`
  - Database version bumped from 3 to 4

- **Seeding Hook** (`useBibleSeed.ts`): New React hook that triggers background seeding on app load and exposes seeding progress. Skips seeding on subsequent loads via seed version check.

- **Type Definitions** (`types/bible.ts`): Added `VerseRecord` and `SearchIndexEntry` interfaces for the new storage structures.

- **Comprehensive Tests** (`seedBibleData.test.ts`, `BibleStorage.test.ts`): Full test coverage for seeding logic, index building, search operations, and storage methods.

## Implementation Details

- Seeding processes books in chunks of 3 with `yieldToBrowser()` calls to keep the UI responsive during initial load
- Search index entries are written in batches of 500 to optimize transaction performance
- Indexed search performs set intersection on keyword matches for AND-based queries
- Results are sorted by book index, chapter, and verse for consistent ordering
- Single-character words are filtered out during tokenization to reduce index size
- Graceful fallback to brute-force search if indexed search fails or index isn't ready yet

https://claude.ai/code/session_018HrmaXLsanSXqLbor7yoys