### PR TITLE
Refactor verse notes section layout and styling

### DIFF
--- a/components/VerseDetails/VerseDetails.module.css
+++ b/components/VerseDetails/VerseDetails.module.css
@@ -45,40 +45,26 @@
 }
 
 .notesSection {
-	margin-top: 24px;
-}
-
-.notesLabel {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	font-size: 13px;
-	font-weight: 500;
-	opacity: 0.6;
-	margin-bottom: 8px;
+	padding: 16px 24px 24px;
 }
 
 .noteTextarea {
 	width: 100%;
-	padding: 12px;
-	font-size: 15px;
-	line-height: 1.5;
+	padding: 0;
+	font-size: 14px;
+	line-height: 1.6;
 	font-family: var(--serif), georgia, serif;
-	background: rgba(0, 0, 0, 0.03);
-	border: 1px solid rgba(0, 0, 0, 0.1);
-	border-radius: 8px;
-	resize: vertical;
+	background: transparent;
+	border: none;
+	resize: none;
 	outline: none;
-	transition: border-color 0.2s;
 	box-sizing: border-box;
-}
-
-.noteTextarea:focus {
-	border-color: rgba(0, 0, 0, 0.3);
+	color: inherit;
 }
 
 .noteTextarea::placeholder {
-	opacity: 0.4;
+	opacity: 0.3;
+	font-style: italic;
 }
 
 .actions {

--- a/components/VerseDetails/VerseDetails.module.css
+++ b/components/VerseDetails/VerseDetails.module.css
@@ -49,9 +49,9 @@
 }
 
 .noteTextarea {
-	width: 100%;
+	width: calc(100% / 0.875);
 	padding: 0;
-	font-size: 14px;
+	font-size: 16px;
 	line-height: 1.6;
 	font-family: var(--serif), georgia, serif;
 	background: transparent;
@@ -60,6 +60,8 @@
 	outline: none;
 	box-sizing: border-box;
 	color: inherit;
+	transform: scale(0.875);
+	transform-origin: top left;
 }
 
 .noteTextarea::placeholder {

--- a/components/VerseDetails/index.tsx
+++ b/components/VerseDetails/index.tsx
@@ -9,7 +9,6 @@ import {
 	IconPlayerPlay,
 	IconShare,
 	IconX,
-	IconNotes,
 } from "@tabler/icons-react";
 import BibleStorage from "../../utils/BibleStorage";
 import type { VerseNote } from "../../types/bible";
@@ -193,21 +192,6 @@ export default function VerseDetails({
 
 			<div className={styles.content}>
 				<p className={styles.verseText}>{text}</p>
-
-				<div className={styles.notesSection}>
-					<label className={styles.notesLabel}>
-						<IconNotes size={16} />
-						Note
-					</label>
-					<textarea
-						className={styles.noteTextarea}
-						placeholder="Add a note..."
-						value={noteText}
-						onChange={(e) => setNoteText(e.target.value)}
-						onBlur={saveNote}
-						rows={3}
-					/>
-				</div>
 			</div>
 
 			<div className={styles.actions}>
@@ -250,6 +234,17 @@ export default function VerseDetails({
 					<IconShare size={24} />
 					<span>Share</span>
 				</button>
+			</div>
+
+			<div className={styles.notesSection}>
+				<textarea
+					className={styles.noteTextarea}
+					placeholder="Add a comment..."
+					value={noteText}
+					onChange={(e) => setNoteText(e.target.value)}
+					onBlur={saveNote}
+					rows={2}
+				/>
 			</div>
 		</Drawer>
 	);


### PR DESCRIPTION
## Summary
Restructured the notes section in the VerseDetails component to appear at the bottom of the drawer instead of within the main content area, and simplified its styling for a cleaner, more minimal appearance.

## Key Changes
- **Layout restructuring**: Moved the notes textarea from inside the content area to the bottom of the drawer, after the action buttons
- **Removed label**: Eliminated the "Note" label with icon that previously appeared above the textarea
- **Simplified styling**: 
  - Changed textarea background from semi-transparent gray to transparent
  - Removed border styling (was `1px solid rgba(0, 0, 0, 0.1)`, now `none`)
  - Removed border-radius and focus state styling
  - Adjusted padding from `12px` to `0` for the textarea itself
  - Updated section padding to `16px 24px 24px`
  - Changed font size from `15px` to `14px` and line-height from `1.5` to `1.6`
- **Updated placeholder**: Changed from "Add a note..." to "Add a comment..." and made it italic
- **Reduced rows**: Changed textarea rows from 3 to 2
- **Removed dependencies**: Removed unused `IconNotes` import from Tabler Icons

## Implementation Details
The notes section now has a more integrated, minimal design that blends seamlessly with the drawer's bottom area. The transparent background and borderless approach creates a cleaner interface while maintaining full functionality for adding and editing verse notes.

https://claude.ai/code/session_01HhREZECQ4hxYtRb3YMFZqu