### PR TITLE
Fix notes UI: rename placeholder, remove double padding, auto-resize textarea, fix iOS keyboard

### DIFF
--- a/components/VerseDetails/VerseDetails.module.css
+++ b/components/VerseDetails/VerseDetails.module.css
@@ -32,7 +32,7 @@
 }
 
 .content {
-	padding: 24px;
+	padding: 24px 0;
 	flex: 1;
 	overflow-y: auto;
 }
@@ -45,7 +45,7 @@
 }
 
 .notesSection {
-	padding: 16px 24px 24px;
+	padding: 16px 0 24px;
 }
 
 .noteTextarea {
@@ -62,17 +62,18 @@
 	color: inherit;
 	transform: scale(0.875);
 	transform-origin: top left;
+	overflow: hidden;
 }
 
 .noteTextarea::placeholder {
-	opacity: 0.3;
+	opacity: 0.5;
 	font-style: italic;
 }
 
 .actions {
 	display: flex;
 	gap: 12px;
-	padding: 20px 24px;
+	padding: 20px 0;
 	border-top: 1px solid rgba(0, 0, 0, 0.1);
 }
 

--- a/components/VerseDetails/index.tsx
+++ b/components/VerseDetails/index.tsx
@@ -38,9 +38,19 @@ export default function VerseDetails({
 	const [isLoading, setIsLoading] = useState(false);
 	const [noteText, setNoteText] = useState("");
 	const [currentNote, setCurrentNote] = useState<VerseNote | null>(null);
+	const [isEditing, setIsEditing] = useState(false);
 	const savedNoteRef = useRef("");
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
 
 	console.log("VerseDetails rendered:", { active, book, chapter, verse });
+
+	useEffect(() => {
+		const textarea = textareaRef.current;
+		if (textarea) {
+			textarea.style.height = "auto";
+			textarea.style.height = textarea.scrollHeight + "px";
+		}
+	}, [noteText]);
 
 	const saveNote = useCallback(async () => {
 		const trimmed = noteText.trim();
@@ -170,7 +180,7 @@ export default function VerseDetails({
 			opened={active}
 			onClose={handleClose}
 			position={isMobile ? "bottom" : "right"}
-			size={isMobile ? "70vh" : "md"}
+			size={isMobile ? (isEditing ? "100%" : "70vh") : "md"}
 			padding="lg"
 			withCloseButton={false}
 		>
@@ -238,12 +248,17 @@ export default function VerseDetails({
 
 			<div className={styles.notesSection}>
 				<textarea
+					ref={textareaRef}
 					className={styles.noteTextarea}
-					placeholder="Add a comment..."
+					placeholder="Add a note..."
 					value={noteText}
 					onChange={(e) => setNoteText(e.target.value)}
-					onBlur={saveNote}
-					rows={2}
+					onFocus={() => setIsEditing(true)}
+					onBlur={() => {
+						setIsEditing(false);
+						saveNote();
+					}}
+					rows={1}
 				/>
 			</div>
 		</Drawer>


### PR DESCRIPTION
- Change "Add a comment..." to "Add a note..." with higher placeholder opacity
- Remove horizontal padding from drawer sections (drawer already provides padding)
- Auto-resize textarea to fit content instead of fixed 2-line truncation
- Expand drawer to 100% on mobile when editing to prevent iOS keyboard gap

https://claude.ai/code/session_01NE4UbaSUqG3dqzXx5bJJw5