### PR TITLE
Remove unused isEditing state from VerseDetails

### DIFF
--- a/components/VerseDetails/index.tsx
+++ b/components/VerseDetails/index.tsx
@@ -38,7 +38,6 @@ export default function VerseDetails({
 	const [isLoading, setIsLoading] = useState(false);
 	const [noteText, setNoteText] = useState("");
 	const [currentNote, setCurrentNote] = useState<VerseNote | null>(null);
-	const [isEditing, setIsEditing] = useState(false);
 	const savedNoteRef = useRef("");
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -180,7 +179,7 @@ export default function VerseDetails({
 			opened={active}
 			onClose={handleClose}
 			position={isMobile ? "bottom" : "right"}
-			size={isMobile ? (isEditing ? "100%" : "70vh") : "md"}
+			size={isMobile ? "70vh" : "md"}
 			padding="lg"
 			withCloseButton={false}
 		>
@@ -253,9 +252,7 @@ export default function VerseDetails({
 					placeholder="Add a note..."
 					value={noteText}
 					onChange={(e) => setNoteText(e.target.value)}
-					onFocus={() => setIsEditing(true)}
 					onBlur={() => {
-						setIsEditing(false);
 						saveNote();
 					}}
 					rows={1}


### PR DESCRIPTION
## Summary
Removed the unused `isEditing` state variable and its associated logic from the VerseDetails component. This simplifies the component by eliminating state that was not providing meaningful functionality.

## Key Changes
- Removed `isEditing` state declaration
- Removed `onFocus` handler that set `isEditing` to true
- Removed `setIsEditing(false)` call from the `onBlur` handler
- Simplified the Drawer `size` prop to always use `"70vh"` on mobile instead of conditionally switching between `"100%"` and `"70vh"` based on editing state

## Implementation Details
The `isEditing` state was being toggled when the textarea gained/lost focus but was only used to conditionally set the drawer size on mobile devices. This conditional sizing logic has been removed in favor of a consistent `"70vh"` size, which appears to be the desired behavior based on the code changes.

https://claude.ai/code/session_01PyDw2nDeKhTHfScMy7eYDa