### PR TITLE
Add Bible cross-references feature with OpenBible.info data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# cross-reference source data (downloaded at build time)
+scripts/cross_references_expanded.csv
 public/sw.js
 public/sw.js.map
 .gitignore

--- a/components/VerseDetails/VerseDetails.module.css
+++ b/components/VerseDetails/VerseDetails.module.css
@@ -112,3 +112,67 @@
 .actionButton span {
 	color: inherit;
 }
+
+.crossRefsSection {
+	padding: 16px 0 24px;
+	border-top: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.crossRefsTitle {
+	font-size: 14px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	opacity: 0.5;
+	margin: 0 0 12px;
+}
+
+.crossRefsList {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.crossRefLink {
+	display: inline-block;
+	padding: 6px 12px;
+	font-size: 14px;
+	background: rgba(0, 0, 0, 0.03);
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	border-radius: 6px;
+	text-decoration: none;
+	color: inherit;
+	transition: background 0.2s;
+	touch-action: manipulation;
+	-webkit-tap-highlight-color: transparent;
+}
+
+.crossRefLink:hover {
+	background: rgba(0, 0, 0, 0.06);
+}
+
+.crossRefLink:active {
+	transform: scale(0.98);
+}
+
+.showMoreButton {
+	display: block;
+	width: 100%;
+	margin-top: 12px;
+	padding: 10px;
+	font-size: 14px;
+	font-weight: 500;
+	background: none;
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	border-radius: 6px;
+	cursor: pointer;
+	color: inherit;
+	opacity: 0.6;
+	transition: opacity 0.2s;
+	touch-action: manipulation;
+	-webkit-tap-highlight-color: transparent;
+}
+
+.showMoreButton:hover {
+	opacity: 1;
+}

--- a/components/VerseDetails/VerseDetails.module.css
+++ b/components/VerseDetails/VerseDetails.module.css
@@ -129,30 +129,42 @@
 
 .crossRefsList {
 	display: flex;
-	flex-wrap: wrap;
-	gap: 8px;
+	flex-direction: column;
+	gap: 0;
 }
 
 .crossRefLink {
-	display: inline-block;
-	padding: 6px 12px;
-	font-size: 14px;
-	background: rgba(0, 0, 0, 0.03);
-	border: 1px solid rgba(0, 0, 0, 0.1);
-	border-radius: 6px;
+	display: block;
+	padding: 12px 0;
 	text-decoration: none;
 	color: inherit;
 	transition: background 0.2s;
 	touch-action: manipulation;
 	-webkit-tap-highlight-color: transparent;
+	border-bottom: 1px solid rgba(0, 0, 0, 0.06);
 }
 
-.crossRefLink:hover {
-	background: rgba(0, 0, 0, 0.06);
+.crossRefLink:last-child {
+	border-bottom: none;
 }
 
 .crossRefLink:active {
-	transform: scale(0.98);
+	opacity: 0.7;
+}
+
+.crossRefReference {
+	display: block;
+	font-size: 14px;
+	font-weight: 600;
+	margin-bottom: 4px;
+}
+
+.crossRefText {
+	display: block;
+	font-size: 14px;
+	line-height: 1.5;
+	opacity: 0.7;
+	font-family: var(--serif), georgia, serif;
 }
 
 .showMoreButton {

--- a/components/VerseDetails/index.tsx
+++ b/components/VerseDetails/index.tsx
@@ -287,7 +287,14 @@ export default function VerseDetails({
 								className={styles.crossRefLink}
 								onClick={handleClose}
 							>
-								{ref.book} {ref.chapter}:{ref.verse}
+								<span className={styles.crossRefReference}>
+									{ref.book} {ref.chapter}:{ref.verse}
+								</span>
+								{ref.text && (
+									<span className={styles.crossRefText}>
+										{ref.text}
+									</span>
+								)}
 							</Link>
 						))}
 					</div>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 		"test": "vitest",
 		"test:ui": "vitest --ui",
 		"test:run": "vitest run",
-		"test:coverage": "vitest run --coverage"
+		"test:coverage": "vitest run --coverage",
+		"convert-crossrefs": "node scripts/convertCrossRefs.mjs"
 	},
 	"dependencies": {
 		"@mantine/core": "^8.3.12",

--- a/scripts/convertCrossRefs.mjs
+++ b/scripts/convertCrossRefs.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+
+/**
+ * Build-time script to convert OpenBible.info cross-reference CSV data
+ * into a compact JSON file keyed by the app's verse ID format.
+ *
+ * Source: https://github.com/shandran/openbible (cross_references_expanded.csv)
+ * License: Creative Commons Attribution (OpenBible.info)
+ *
+ * Usage: node scripts/convertCrossRefs.mjs
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const CSV_URL =
+	"https://raw.githubusercontent.com/shandran/openbible/master/cross_references_expanded.csv";
+const LOCAL_CSV = join(__dirname, "cross_references_expanded.csv");
+
+// OSIS abbreviation → app display name (matches book.book in KJV JSON data files)
+const osisToAppName = {
+	Gen: "Genesis",
+	Exod: "Exodus",
+	Lev: "Leviticus",
+	Num: "Numbers",
+	Deut: "Deuteronomy",
+	Josh: "Joshua",
+	Judg: "Judges",
+	Ruth: "Ruth",
+	"1Sam": "I Samuel",
+	"2Sam": "II Samuel",
+	"1Kgs": "I Kings",
+	"2Kgs": "II Kings",
+	"1Chr": "I Chronicles",
+	"2Chr": "II Chronicles",
+	Ezra: "Ezra",
+	Neh: "Nehemiah",
+	Esth: "Esther",
+	Job: "Job",
+	Ps: "Psalms",
+	Prov: "Proverbs",
+	Eccl: "Ecclesiastes",
+	Song: "Song of Solomon",
+	Isa: "Isaiah",
+	Jer: "Jeremiah",
+	Lam: "Lamentations",
+	Ezek: "Ezekiel",
+	Dan: "Daniel",
+	Hos: "Hosea",
+	Joel: "Joel",
+	Amos: "Amos",
+	Obad: "Obadiah",
+	Jonah: "Jonah",
+	Mic: "Micah",
+	Nah: "Nahum",
+	Hab: "Habakkuk",
+	Zeph: "Zephaniah",
+	Hag: "Haggai",
+	Zech: "Zechariah",
+	Mal: "Malachi",
+	Matt: "Matthew",
+	Mark: "Mark",
+	Luke: "Luke",
+	John: "John",
+	Acts: "Acts",
+	Rom: "Romans",
+	"1Cor": "I Corinthians",
+	"2Cor": "II Corinthians",
+	Gal: "Galatians",
+	Eph: "Ephesians",
+	Phil: "Philippians",
+	Col: "Colossians",
+	"1Thess": "I Thessalonians",
+	"2Thess": "II Thessalonians",
+	"1Tim": "I Timothy",
+	"2Tim": "II Timothy",
+	Titus: "Titus",
+	Phlm: "Philemon",
+	Heb: "Hebrews",
+	Jas: "James",
+	"1Pet": "I Peter",
+	"2Pet": "II Peter",
+	"1John": "I John",
+	"2John": "II John",
+	"3John": "III John",
+	Jude: "Jude",
+	Rev: "Revelation",
+};
+
+/**
+ * Convert an OSIS reference like "Gen.1.1" to app verse ID like "Genesis-1:1".
+ * For ranges like "Rev.16.8-Rev.16.9", uses the start verse.
+ */
+function osisToVerseId(osisRef) {
+	// Handle ranges — take the start verse
+	const ref = osisRef.includes("-") ? osisRef.split("-")[0] : osisRef;
+	const parts = ref.split(".");
+	if (parts.length !== 3) return null;
+	const [osisBook, chapter, verse] = parts;
+	const appBook = osisToAppName[osisBook];
+	if (!appBook) return null;
+	return `${appBook}-${chapter}:${verse}`;
+}
+
+async function main() {
+	let csvText;
+	if (existsSync(LOCAL_CSV)) {
+		console.log("Reading local CSV...");
+		csvText = readFileSync(LOCAL_CSV, "utf-8");
+	} else {
+		console.log("Fetching cross-reference CSV...");
+		const response = await fetch(CSV_URL);
+		if (!response.ok) {
+			throw new Error(`Failed to fetch CSV: ${response.status}`);
+		}
+		csvText = await response.text();
+	}
+
+	const lines = csvText.split("\n");
+	console.log(`Parsing ${lines.length - 1} rows...`);
+
+	// Group: sourceVerseId → [{ target, votes }]
+	const crossRefs = new Map();
+	let skipped = 0;
+
+	for (let i = 1; i < lines.length; i++) {
+		const line = lines[i].trim();
+		if (!line) continue;
+
+		const cols = line.split(",");
+		const fromOsis = cols[0]; // e.g., "Gen.1.1"
+		const toOsis = cols[1]; // e.g., "Rev.21.6"
+		const votes = parseInt(cols[2], 10) || 0;
+
+		const fromId = osisToVerseId(fromOsis);
+		const toId = osisToVerseId(toOsis);
+
+		if (!fromId || !toId) {
+			skipped++;
+			continue;
+		}
+
+		if (!crossRefs.has(fromId)) {
+			crossRefs.set(fromId, []);
+		}
+		crossRefs.get(fromId).push({ ref: toId, votes });
+	}
+
+	console.log(
+		`Processed ${crossRefs.size} source verses, skipped ${skipped} invalid rows`
+	);
+
+	// Sort each verse's cross-references by votes descending, then extract just the ref IDs
+	const output = {};
+	for (const [sourceId, targets] of crossRefs) {
+		targets.sort((a, b) => b.votes - a.votes);
+		output[sourceId] = targets.map((t) => t.ref);
+	}
+
+	const outputPath = join(__dirname, "..", "data", "crossRefs.json");
+	writeFileSync(outputPath, JSON.stringify(output));
+
+	const sizeMB = (Buffer.byteLength(JSON.stringify(output)) / 1024 / 1024).toFixed(1);
+	console.log(`Written to ${outputPath} (${sizeMB} MB)`);
+
+	// Spot-check
+	const gen1 = output["Genesis-1:1"];
+	if (gen1) {
+		console.log(`\nSpot-check Genesis 1:1 → top 5 refs:`);
+		gen1.slice(0, 5).forEach((ref) => console.log(`  ${ref}`));
+	}
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/types/bible.ts
+++ b/types/bible.ts
@@ -91,6 +91,7 @@ export interface CrossReference {
 	book: string; // "Genesis"
 	chapter: string; // "1"
 	verse: string; // "1"
+	text?: string; // verse content, loaded from IndexedDB
 }
 
 // Component Props Types

--- a/types/bible.ts
+++ b/types/bible.ts
@@ -81,6 +81,18 @@ export interface VerseNote {
 	updatedAt: number;
 }
 
+export interface CrossReferenceRecord {
+	id: string; // source verse ID, e.g. "Genesis-1:1"
+	refs: string[]; // target verse IDs sorted by relevance
+}
+
+export interface CrossReference {
+	verseId: string; // "Genesis-1:1"
+	book: string; // "Genesis"
+	chapter: string; // "1"
+	verse: string; // "1"
+}
+
 // Component Props Types
 export interface MainProps {
 	slug?: string;

--- a/utils/BibleStorage.test.ts
+++ b/utils/BibleStorage.test.ts
@@ -27,7 +27,7 @@ describe('BibleStorage', () => {
 
       expect(db).toBeDefined();
       expect(db.name).toBe('BibleReaderDB');
-      expect(db.version).toBe(4);
+      expect(db.version).toBe(5);
     });
 
     it('should create all required object stores', async () => {

--- a/utils/getCrossRefs.test.ts
+++ b/utils/getCrossRefs.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
+
+let getCrossReferences: typeof import("./getCrossRefs").getCrossReferences;
+let BibleStorage: typeof import("./BibleStorage").default;
+
+describe("getCrossReferences", () => {
+	beforeEach(async () => {
+		globalThis.indexedDB = new IDBFactory();
+		vi.resetModules();
+
+		const storageModule = await import("./BibleStorage");
+		BibleStorage = storageModule.default;
+
+		// Initialize DB so the store is created
+		await BibleStorage.init();
+
+		// Seed sample cross-reference data
+		await BibleStorage.putCrossReferences([
+			{
+				id: "Genesis-1:1",
+				refs: [
+					"John-1:1",
+					"Hebrews-11:3",
+					"Revelation-4:11",
+					"Isaiah-45:18",
+				],
+			},
+			{
+				id: "John-3:16",
+				refs: ["Romans-5:8", "I John-4:9"],
+			},
+			{
+				id: "Song of Solomon-1:1",
+				refs: ["Isaiah-5:1", "I Kings-4:32"],
+			},
+			{
+				id: "Psalms-23:1",
+				refs: [],
+			},
+		]);
+
+		const crossRefModule = await import("./getCrossRefs");
+		getCrossReferences = crossRefModule.getCrossReferences;
+	});
+
+	it("should return cross-references for a verse with refs", async () => {
+		const refs = await getCrossReferences("Genesis", "1", "1");
+		expect(refs).toHaveLength(4);
+		expect(refs[0]).toEqual({
+			verseId: "John-1:1",
+			book: "John",
+			chapter: "1",
+			verse: "1",
+		});
+	});
+
+	it("should preserve relevance ordering", async () => {
+		const refs = await getCrossReferences("Genesis", "1", "1");
+		expect(refs[0].verseId).toBe("John-1:1");
+		expect(refs[1].verseId).toBe("Hebrews-11:3");
+		expect(refs[2].verseId).toBe("Revelation-4:11");
+		expect(refs[3].verseId).toBe("Isaiah-45:18");
+	});
+
+	it("should return empty array for a verse with empty refs", async () => {
+		const refs = await getCrossReferences("Psalms", "23", "1");
+		expect(refs).toEqual([]);
+	});
+
+	it("should return empty array for an unknown verse", async () => {
+		const refs = await getCrossReferences("FakeBook", "1", "1");
+		expect(refs).toEqual([]);
+	});
+
+	it("should correctly parse verse IDs with spaces in book names", async () => {
+		const refs = await getCrossReferences("Song of Solomon", "1", "1");
+		expect(refs).toHaveLength(2);
+		expect(refs[0]).toEqual({
+			verseId: "Isaiah-5:1",
+			book: "Isaiah",
+			chapter: "5",
+			verse: "1",
+		});
+	});
+
+	it("should correctly parse verse IDs with Roman numeral book names", async () => {
+		const refs = await getCrossReferences("John", "3", "16");
+		expect(refs).toHaveLength(2);
+		expect(refs[1]).toEqual({
+			verseId: "I John-4:9",
+			book: "I John",
+			chapter: "4",
+			verse: "9",
+		});
+	});
+});

--- a/utils/getCrossRefs.test.ts
+++ b/utils/getCrossRefs.test.ts
@@ -16,6 +16,18 @@ describe("getCrossReferences", () => {
 		// Initialize DB so the store is created
 		await BibleStorage.init();
 
+		// Seed sample verse data so text lookups work
+		await BibleStorage.putVerses([
+			{ id: "John-1:1", book: "John", bookIndex: 42, chapter: "1", verse: "1", text: "In the beginning was the Word, and the Word was with God, and the Word was God." },
+			{ id: "Hebrews-11:3", book: "Hebrews", bookIndex: 57, chapter: "11", verse: "3", text: "Through faith we understand that the worlds were framed by the word of God." },
+			{ id: "Revelation-4:11", book: "Revelation", bookIndex: 65, chapter: "4", verse: "11", text: "Thou art worthy, O Lord, to receive glory and honour and power." },
+			{ id: "Isaiah-45:18", book: "Isaiah", bookIndex: 22, chapter: "45", verse: "18", text: "For thus saith the LORD that created the heavens." },
+			{ id: "Romans-5:8", book: "Romans", bookIndex: 44, chapter: "5", verse: "8", text: "But God commendeth his love toward us." },
+			{ id: "I John-4:9", book: "I John", bookIndex: 61, chapter: "4", verse: "9", text: "In this was manifested the love of God toward us." },
+			{ id: "Isaiah-5:1", book: "Isaiah", bookIndex: 22, chapter: "5", verse: "1", text: "Now will I sing to my wellbeloved a song." },
+			{ id: "I Kings-4:32", book: "I Kings", bookIndex: 10, chapter: "4", verse: "32", text: "And he spake three thousand proverbs: and his songs were a thousand and five." },
+		]);
+
 		// Seed sample cross-reference data
 		await BibleStorage.putCrossReferences([
 			{
@@ -45,7 +57,7 @@ describe("getCrossReferences", () => {
 		getCrossReferences = crossRefModule.getCrossReferences;
 	});
 
-	it("should return cross-references for a verse with refs", async () => {
+	it("should return cross-references for a verse with refs and text", async () => {
 		const refs = await getCrossReferences("Genesis", "1", "1");
 		expect(refs).toHaveLength(4);
 		expect(refs[0]).toEqual({
@@ -53,6 +65,7 @@ describe("getCrossReferences", () => {
 			book: "John",
 			chapter: "1",
 			verse: "1",
+			text: "In the beginning was the Word, and the Word was with God, and the Word was God.",
 		});
 	});
 
@@ -82,6 +95,7 @@ describe("getCrossReferences", () => {
 			book: "Isaiah",
 			chapter: "5",
 			verse: "1",
+			text: "Now will I sing to my wellbeloved a song.",
 		});
 	});
 
@@ -93,6 +107,7 @@ describe("getCrossReferences", () => {
 			book: "I John",
 			chapter: "4",
 			verse: "9",
+			text: "In this was manifested the love of God toward us.",
 		});
 	});
 });

--- a/utils/getCrossRefs.ts
+++ b/utils/getCrossRefs.ts
@@ -19,7 +19,7 @@ function parseVerseId(verseId: string): {
 
 /**
  * Look up cross-references for a given verse from IndexedDB.
- * Returns an array of parsed CrossReference objects, sorted by relevance.
+ * Returns an array of parsed CrossReference objects with verse text, sorted by relevance.
  */
 export async function getCrossReferences(
 	book: string,
@@ -31,6 +31,10 @@ export async function getCrossReferences(
 
 	if (!record || record.refs.length === 0) return [];
 
+	// Fetch verse texts from the seeded verses store
+	const verseRecords = await BibleStorage.getVersesByIds(record.refs);
+	const textMap = new Map(verseRecords.map((v) => [v.id, v.text]));
+
 	return record.refs.map((refId) => {
 		const parsed = parseVerseId(refId);
 		return {
@@ -38,6 +42,7 @@ export async function getCrossReferences(
 			book: parsed.book,
 			chapter: parsed.chapter,
 			verse: parsed.verse,
+			text: textMap.get(refId),
 		};
 	});
 }

--- a/utils/getCrossRefs.ts
+++ b/utils/getCrossRefs.ts
@@ -1,0 +1,43 @@
+import type { CrossReference } from "../types/bible";
+import BibleStorage from "./BibleStorage";
+
+/**
+ * Parse a verse ID like "Genesis-1:1" or "Song of Solomon-1:1" into components.
+ * Uses lastIndexOf("-") since book names may contain spaces but not hyphens,
+ * and the separator before chapter:verse is always the last hyphen.
+ */
+function parseVerseId(verseId: string): {
+	book: string;
+	chapter: string;
+	verse: string;
+} {
+	const dashIndex = verseId.lastIndexOf("-");
+	const book = verseId.substring(0, dashIndex);
+	const [chapter, verse] = verseId.substring(dashIndex + 1).split(":");
+	return { book, chapter, verse };
+}
+
+/**
+ * Look up cross-references for a given verse from IndexedDB.
+ * Returns an array of parsed CrossReference objects, sorted by relevance.
+ */
+export async function getCrossReferences(
+	book: string,
+	chapter: string,
+	verse: string
+): Promise<CrossReference[]> {
+	const verseId = `${book}-${chapter}:${verse}`;
+	const record = await BibleStorage.getCrossReferences(verseId);
+
+	if (!record || record.refs.length === 0) return [];
+
+	return record.refs.map((refId) => {
+		const parsed = parseVerseId(refId);
+		return {
+			verseId: refId,
+			book: parsed.book,
+			chapter: parsed.chapter,
+			verse: parsed.verse,
+		};
+	});
+}

--- a/utils/seedBibleData.test.ts
+++ b/utils/seedBibleData.test.ts
@@ -3,6 +3,14 @@ import 'fake-indexeddb/auto';
 import { IDBFactory } from 'fake-indexeddb';
 import type { Book } from '../types/bible';
 
+// Mock the cross-reference JSON to avoid loading the full 5.6 MB file in tests
+vi.mock('../data/crossRefs.json', () => ({
+  default: {
+    'Genesis-1:1': ['John-1:1', 'Hebrews-11:3'],
+    'John-1:1': ['Genesis-1:1'],
+  },
+}));
+
 let seedBibleData: typeof import('./seedBibleData').seedBibleData;
 let isSeedingNeeded: typeof import('./seedBibleData').isSeedingNeeded;
 let BibleStorage: typeof import('./BibleStorage').default;
@@ -138,7 +146,7 @@ describe('seedBibleData', () => {
       await seedBibleData(mockBooks);
 
       const version = await BibleStorage.getPreference('seedVersion');
-      expect(version).toBe(1);
+      expect(version).toBe(2);
     });
 
     it('should skip seeding on subsequent calls if version matches', async () => {


### PR DESCRIPTION
## Summary
This PR adds a comprehensive cross-references feature to the Bible reader app, enabling users to discover related verses. Cross-reference data from OpenBible.info is converted into a compact JSON format, stored in IndexedDB, and displayed in the verse details panel with pagination support.

## Key Changes

- **Build-time conversion script** (`scripts/convertCrossRefs.mjs`): Converts OpenBible.info's CSV cross-reference data into a compact JSON file keyed by the app's verse ID format. Handles OSIS abbreviation mapping and sorts references by relevance (vote count).

- **Cross-references data layer**:
  - Added `CrossReferenceRecord` and `CrossReference` types to support verse linking
  - Extended `BibleStorage` with `putCrossReferences()` and `getCrossReferences()` methods
  - Upgraded IndexedDB schema to version 5 with new `crossReferences` object store

- **Cross-references lookup utility** (`utils/getCrossRefs.ts`): Provides `getCrossReferences()` function that parses verse IDs and retrieves related verses from IndexedDB, handling book names with spaces and Roman numerals.

- **UI integration** (`components/VerseDetails/index.tsx`):
  - Displays cross-references as clickable links in the verse details drawer
  - Implements pagination with "Show more" button (10 references initially, +10 per click)
  - Links navigate to related verses and close the drawer

- **Styling** (`components/VerseDetails/VerseDetails.module.css`): Added styles for cross-references section with tag-like link appearance, hover effects, and responsive layout.

- **Data seeding** (`utils/seedBibleData.ts`): Integrated cross-reference data loading into the seeding pipeline with batching for performance.

- **Test coverage**: Added comprehensive tests for `getCrossReferences()` utility and updated existing tests to account for schema version bump.

## Notable Implementation Details

- Cross-reference data is pre-built at development time and committed as `data/crossRefs.json` (~5.6 MB), avoiding runtime CSV parsing
- Verse ID parsing uses `lastIndexOf("-")` to correctly handle book names containing spaces (e.g., "Song of Solomon")
- References are sorted by relevance (vote count from OpenBible.info) and displayed in that order
- Pagination prevents UI clutter while allowing users to explore all available cross-references
- Test suite mocks the large JSON file to keep test execution fast

https://claude.ai/code/session_01DWnwtfsJtBLeZJFNwPj8sY