### PR TITLE
Fix drawer horizontal scrollbar on mobile and rename title to References

### DIFF
--- a/components/VerseDetails/VerseDetails.module.css
+++ b/components/VerseDetails/VerseDetails.module.css
@@ -46,6 +46,7 @@
 
 .notesSection {
 	padding: 16px 0 24px;
+	overflow: hidden;
 }
 
 .noteTextarea {

--- a/components/VerseDetails/index.tsx
+++ b/components/VerseDetails/index.tsx
@@ -276,7 +276,7 @@ export default function VerseDetails({
 
 			{crossRefs.length > 0 && (
 				<div className={styles.crossRefsSection}>
-					<h4 className={styles.crossRefsTitle}>Cross References</h4>
+					<h4 className={styles.crossRefsTitle}>References</h4>
 					<div className={styles.crossRefsList}>
 						{crossRefs.slice(0, visibleCrossRefs).map((ref) => (
 							<Link


### PR DESCRIPTION
Add overflow: hidden to .notesSection to prevent the scaled textarea
(width: calc(100% / 0.875) with transform: scale(0.875)) from causing
a horizontal scrollbar. Rename "Cross References" heading to "References".

https://claude.ai/code/session_01FRPeFo9M1SaQt5KrG64PSJ