### PR TITLE
Add opt-in Knuth-Plass text justification via @chenglou/pretext

### DIFF
--- a/components/Reader/Reader.module.css
+++ b/components/Reader/Reader.module.css
@@ -31,6 +31,7 @@
 .chapter {
 	width: 100%;
 	max-width: 70ch;
+	font-family: var(--serif), georgia, serif;
 	line-height: 24px;
 	grid-column: main;
 	margin-bottom: 24px;
@@ -58,6 +59,12 @@
 
 .ptLine .verse {
 	display: inline;
+}
+
+.ptLine .verse sup {
+	padding-left: 0.3ex;
+	padding-right: 0;
+	margin-right: 0;
 }
 
 .verseAnchor {

--- a/components/Reader/Reader.module.css
+++ b/components/Reader/Reader.module.css
@@ -45,7 +45,7 @@
 }
 
 .chapterNumber + p sup,
-.chapterNumber + .ptLine .verse sup:first-of-type {
+.chapterNumber + .ptLine sup {
 	display: none;
 }
 

--- a/components/Reader/Reader.module.css
+++ b/components/Reader/Reader.module.css
@@ -44,8 +44,31 @@
 	margin-right: 0.25ex;
 }
 
-.chapterNumber + p sup {
+.chapterNumber + p sup,
+.chapterNumber + .ptLine .verse sup:first-of-type {
 	display: none;
+}
+
+.ptLine {
+	display: block;
+	white-space: nowrap;
+	font-family: var(--serif), georgia, serif;
+}
+
+.ptLine .verse {
+	display: inline;
+	white-space: nowrap;
+}
+
+.ptLineLast {
+	white-space: normal;
+}
+
+.verseAnchor {
+	display: inline-block;
+	width: 0;
+	height: 0;
+	overflow: hidden;
 }
 
 .verse {

--- a/components/Reader/Reader.module.css
+++ b/components/Reader/Reader.module.css
@@ -160,6 +160,35 @@
 	background: rgba(255, 200, 0, 0.15);
 }
 
+.justificationToggle {
+	position: fixed;
+	bottom: calc(70px + env(safe-area-inset-bottom));
+	right: 16px;
+	z-index: 100;
+	width: 40px;
+	height: 40px;
+	border-radius: 50%;
+	border: 1px solid rgba(0, 0, 0, 0.15);
+	background: rgba(255, 255, 255, 0.9);
+	backdrop-filter: blur(8px);
+	font-size: 11px;
+	font-weight: 600;
+	font-family: system-ui, sans-serif;
+	color: rgba(0, 0, 0, 0.5);
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: background 0.15s, color 0.15s;
+	-webkit-tap-highlight-color: transparent;
+	touch-action: manipulation;
+}
+
+.justificationToggle:hover {
+	background: rgba(255, 255, 255, 1);
+	color: rgba(0, 0, 0, 0.8);
+}
+
 @keyframes highlightFade {
 	0% {
 		background: transparent;

--- a/components/Reader/Reader.module.css
+++ b/components/Reader/Reader.module.css
@@ -29,10 +29,12 @@
 }
 
 .chapter {
+	width: 100%;
 	max-width: 70ch;
 	line-height: 24px;
 	grid-column: main;
 	margin-bottom: 24px;
+	overflow-x: hidden;
 }
 
 .chapterNumber {
@@ -51,17 +53,11 @@
 
 .ptLine {
 	display: block;
-	white-space: nowrap;
 	font-family: var(--serif), georgia, serif;
 }
 
 .ptLine .verse {
 	display: inline;
-	white-space: nowrap;
-}
-
-.ptLineLast {
-	white-space: normal;
 }
 
 .verseAnchor {

--- a/components/Reader/TypesetChapter/index.tsx
+++ b/components/Reader/TypesetChapter/index.tsx
@@ -97,18 +97,15 @@ export default function TypesetChapter({
 	useEffect(() => {
 		if (!chapterEl) return;
 
-		const width = chapterEl.offsetWidth;
-		if (width > 0) setContainerWidth(width);
+		const measure = () => {
+			const width = chapterEl.offsetWidth;
+			if (width > 0) setContainerWidth(width);
+		};
 
-		const observer = new ResizeObserver((entries) => {
-			const entry = entries[0];
-			if (!entry) return;
-			const newWidth = entry.contentRect.width;
-			if (newWidth > 0) setContainerWidth(newWidth);
-		});
+		measure();
 
-		observer.observe(chapterEl);
-		return () => observer.disconnect();
+		window.addEventListener("resize", measure);
+		return () => window.removeEventListener("resize", measure);
 	}, [chapterEl]);
 
 	const runs = useMemo(

--- a/components/Reader/TypesetChapter/index.tsx
+++ b/components/Reader/TypesetChapter/index.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useRef, useCallback, useMemo } from "react";
+import styles from "../Reader.module.css";
+import type { Chapter } from "../../../types/bible";
+import { buildParagraphRuns } from "../../../utils/typeset/paragraphBuilder";
+import { useTypeset } from "../../../utils/useTypeset";
+import { renderPositionedLines } from "../../../utils/typeset/renderLines";
+
+interface TypesetChapterProps {
+	chapter: Chapter;
+	bookName: string;
+	chaptersCount: number;
+	highlightVerse: string | null;
+	readingVerse: string | null;
+	selectedVerse: { chapter: string; verse: string } | null;
+	onPointerDown: (e: React.PointerEvent) => void;
+	onVerseClick: (chapter: string, verse: string, text: string) => void;
+}
+
+function TypesetParagraphRun({
+	input,
+	verseNumbers,
+	containerEl,
+	handlers,
+}: {
+	input: import("../../../utils/typeset/types").ParagraphInput;
+	verseNumbers: Map<string, string>;
+	containerEl: HTMLElement | null;
+	handlers: {
+		onPointerDown: (e: React.PointerEvent) => void;
+		onPointerUp: (e: React.PointerEvent, verseId: string, text: string) => void;
+		highlightVerse: string | null;
+		readingVerse: string | null;
+		selectedVerse: { chapter: string; verse: string } | null;
+	};
+}) {
+	const { lines } = useTypeset(input, containerEl, true);
+
+	if (!lines) {
+		// Fallback: render as native inline verses while typesetting computes
+		return (
+			<>
+				{input.verseMap.map((entry) => {
+					const verseNum = verseNumbers.get(entry.verseId);
+					const text = input.text.slice(entry.start, entry.end);
+					return (
+						<p
+							key={entry.verseId}
+							id={entry.verseId}
+							className={`${styles.verse} verse`}
+							onPointerDown={handlers.onPointerDown}
+							onPointerUp={(e) =>
+								handlers.onPointerUp(e, entry.verseId, text)
+							}
+						>
+							{verseNum && <sup>{verseNum}&nbsp;</sup>}
+							{text}
+						</p>
+					);
+				})}
+			</>
+		);
+	}
+
+	return (
+		<>
+			{renderPositionedLines({
+				lines,
+				verseMap: input.verseMap,
+				verseNumbers,
+				handlers,
+				paragraphText: input.text,
+			})}
+		</>
+	);
+}
+
+export default function TypesetChapter({
+	chapter,
+	bookName,
+	chaptersCount,
+	highlightVerse,
+	readingVerse,
+	selectedVerse,
+	onPointerDown,
+	onVerseClick,
+}: TypesetChapterProps) {
+	const chapterRef = useRef<HTMLDivElement>(null);
+	const isSingleChapterBook = chaptersCount < 2;
+
+	const runs = useMemo(
+		() => buildParagraphRuns(chapter, isSingleChapterBook),
+		[chapter, isSingleChapterBook],
+	);
+
+	const handlePointerUp = useCallback(
+		(e: React.PointerEvent, verseId: string, text: string) => {
+			const [ch, vs] = verseId.split(":");
+			if (ch && vs) {
+				onVerseClick(ch, vs, text);
+			}
+		},
+		[onVerseClick],
+	);
+
+	const handlers = useMemo(
+		() => ({
+			onPointerDown,
+			onPointerUp: handlePointerUp,
+			highlightVerse,
+			readingVerse,
+			selectedVerse,
+		}),
+		[onPointerDown, handlePointerUp, highlightVerse, readingVerse, selectedVerse],
+	);
+
+	const firstVerse = chapter.verses[0];
+	const showDropCap = chaptersCount > 1 || !firstVerse;
+	const dropCapChar = !showDropCap && firstVerse ? firstVerse.text[0] : null;
+
+	return (
+		<div
+			ref={chapterRef}
+			key={chapter.chapter}
+			className={`${styles.chapter} ${bookName === "Psalms" ? styles.psalm : ""}`}
+			id={chapter.chapter.toString()}
+		>
+			<h2 className={styles.chapterNumber}>
+				{chaptersCount > 1 ? chapter.chapter : dropCapChar}
+			</h2>
+
+			{runs.map((run, runIdx) => {
+				if (run.kind === "psalmTitle") {
+					return (
+						<span key={`st-${runIdx}`} className={styles.psalmTitle}>
+							{run.text}
+						</span>
+					);
+				}
+
+				if (run.kind === "poetry") {
+					return (
+						<p
+							key={run.verseId}
+							id={run.verseId}
+							className={`${styles.verse} verse ${styles.poetry} ${
+								run.isNewParagraph ? styles.newParagraph : ""
+							} ${highlightVerse === run.verseId ? styles.selected : ""} ${
+								readingVerse === run.verseId ? styles.reading : ""
+							} ${
+								selectedVerse &&
+								run.verseId === `${selectedVerse.chapter}:${selectedVerse.verse}`
+									? styles.selected
+									: ""
+							}`}
+							onPointerDown={onPointerDown}
+							onPointerUp={(e) =>
+								handlePointerUp(e, run.verseId, run.text)
+							}
+						>
+							<sup>{run.verseNumber}&nbsp;</sup>
+							{run.text}
+						</p>
+					);
+				}
+
+				return (
+					<TypesetParagraphRun
+						key={`pr-${runIdx}`}
+						input={run.input}
+						verseNumbers={run.verseNumbers}
+						containerEl={chapterRef.current}
+						handlers={handlers}
+					/>
+				);
+			})}
+		</div>
+	);
+}

--- a/components/Reader/TypesetChapter/index.tsx
+++ b/components/Reader/TypesetChapter/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useCallback, useMemo } from "react";
+import { useRef, useCallback, useMemo, useState } from "react";
 import styles from "../Reader.module.css";
 import type { Chapter } from "../../../types/bible";
 import { buildParagraphRuns } from "../../../utils/typeset/paragraphBuilder";
@@ -83,7 +83,10 @@ export default function TypesetChapter({
 	selectedVerse,
 	onVerseClick,
 }: TypesetChapterProps) {
-	const chapterRef = useRef<HTMLDivElement>(null);
+	const [chapterEl, setChapterEl] = useState<HTMLDivElement | null>(null);
+	const chapterRef = useCallback((node: HTMLDivElement | null) => {
+		setChapterEl(node);
+	}, []);
 	const pointerStartRef = useRef<{ x: number; y: number } | null>(null);
 	const isSingleChapterBook = chaptersCount < 2;
 
@@ -178,7 +181,7 @@ export default function TypesetChapter({
 						key={`pr-${runIdx}`}
 						input={run.input}
 						verseNumbers={run.verseNumbers}
-						containerEl={chapterRef.current}
+						containerEl={chapterEl}
 						handlers={handlers}
 					/>
 				);

--- a/components/Reader/TypesetChapter/index.tsx
+++ b/components/Reader/TypesetChapter/index.tsx
@@ -14,7 +14,6 @@ interface TypesetChapterProps {
 	highlightVerse: string | null;
 	readingVerse: string | null;
 	selectedVerse: { chapter: string; verse: string } | null;
-	onPointerDown: (e: React.PointerEvent) => void;
 	onVerseClick: (chapter: string, verse: string, text: string) => void;
 }
 
@@ -38,7 +37,6 @@ function TypesetParagraphRun({
 	const { lines } = useTypeset(input, containerEl, true);
 
 	if (!lines) {
-		// Fallback: render as native inline verses while typesetting computes
 		return (
 			<>
 				{input.verseMap.map((entry) => {
@@ -83,10 +81,10 @@ export default function TypesetChapter({
 	highlightVerse,
 	readingVerse,
 	selectedVerse,
-	onPointerDown,
 	onVerseClick,
 }: TypesetChapterProps) {
 	const chapterRef = useRef<HTMLDivElement>(null);
+	const pointerStartRef = useRef<{ x: number; y: number } | null>(null);
 	const isSingleChapterBook = chaptersCount < 2;
 
 	const runs = useMemo(
@@ -94,8 +92,18 @@ export default function TypesetChapter({
 		[chapter, isSingleChapterBook],
 	);
 
+	const handlePointerDown = useCallback((e: React.PointerEvent) => {
+		pointerStartRef.current = { x: e.clientX, y: e.clientY };
+	}, []);
+
 	const handlePointerUp = useCallback(
 		(e: React.PointerEvent, verseId: string, text: string) => {
+			const start = pointerStartRef.current;
+			pointerStartRef.current = null;
+			if (!start) return;
+			const dx = Math.abs(e.clientX - start.x);
+			const dy = Math.abs(e.clientY - start.y);
+			if (dx > 10 || dy > 10) return;
 			const [ch, vs] = verseId.split(":");
 			if (ch && vs) {
 				onVerseClick(ch, vs, text);
@@ -106,13 +114,13 @@ export default function TypesetChapter({
 
 	const handlers = useMemo(
 		() => ({
-			onPointerDown,
+			onPointerDown: handlePointerDown,
 			onPointerUp: handlePointerUp,
 			highlightVerse,
 			readingVerse,
 			selectedVerse,
 		}),
-		[onPointerDown, handlePointerUp, highlightVerse, readingVerse, selectedVerse],
+		[handlePointerDown, handlePointerUp, highlightVerse, readingVerse, selectedVerse],
 	);
 
 	const firstVerse = chapter.verses[0];
@@ -154,7 +162,7 @@ export default function TypesetChapter({
 									? styles.selected
 									: ""
 							}`}
-							onPointerDown={onPointerDown}
+							onPointerDown={handlePointerDown}
 							onPointerUp={(e) =>
 								handlePointerUp(e, run.verseId, run.text)
 							}

--- a/components/Reader/TypesetChapter/index.tsx
+++ b/components/Reader/TypesetChapter/index.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useRef, useCallback, useMemo, useState } from "react";
+import { useRef, useCallback, useMemo, useState, useEffect } from "react";
 import styles from "../Reader.module.css";
 import type { Chapter } from "../../../types/bible";
 import { buildParagraphRuns } from "../../../utils/typeset/paragraphBuilder";
 import { useTypeset } from "../../../utils/useTypeset";
 import { renderPositionedLines } from "../../../utils/typeset/renderLines";
+import type { ParagraphInput } from "../../../utils/typeset/types";
 
 interface TypesetChapterProps {
 	chapter: Chapter;
@@ -20,11 +21,13 @@ interface TypesetChapterProps {
 function TypesetParagraphRun({
 	input,
 	verseNumbers,
+	containerWidth,
 	containerEl,
 	handlers,
 }: {
-	input: import("../../../utils/typeset/types").ParagraphInput;
+	input: ParagraphInput;
 	verseNumbers: Map<string, string>;
+	containerWidth: number;
 	containerEl: HTMLElement | null;
 	handlers: {
 		onPointerDown: (e: React.PointerEvent) => void;
@@ -34,7 +37,7 @@ function TypesetParagraphRun({
 		selectedVerse: { chapter: string; verse: string } | null;
 	};
 }) {
-	const { lines } = useTypeset(input, containerEl, true);
+	const { lines } = useTypeset(input, containerWidth, containerEl, true);
 
 	if (!lines) {
 		return (
@@ -84,11 +87,29 @@ export default function TypesetChapter({
 	onVerseClick,
 }: TypesetChapterProps) {
 	const [chapterEl, setChapterEl] = useState<HTMLDivElement | null>(null);
+	const [containerWidth, setContainerWidth] = useState(0);
 	const chapterRef = useCallback((node: HTMLDivElement | null) => {
 		setChapterEl(node);
 	}, []);
 	const pointerStartRef = useRef<{ x: number; y: number } | null>(null);
 	const isSingleChapterBook = chaptersCount < 2;
+
+	useEffect(() => {
+		if (!chapterEl) return;
+
+		const width = chapterEl.offsetWidth;
+		if (width > 0) setContainerWidth(width);
+
+		const observer = new ResizeObserver((entries) => {
+			const entry = entries[0];
+			if (!entry) return;
+			const newWidth = entry.contentRect.width;
+			if (newWidth > 0) setContainerWidth(newWidth);
+		});
+
+		observer.observe(chapterEl);
+		return () => observer.disconnect();
+	}, [chapterEl]);
 
 	const runs = useMemo(
 		() => buildParagraphRuns(chapter, isSingleChapterBook),
@@ -141,7 +162,7 @@ export default function TypesetChapter({
 				{chaptersCount > 1 ? chapter.chapter : dropCapChar}
 			</h2>
 
-			{runs.map((run, runIdx) => {
+			{containerWidth > 0 && runs.map((run, runIdx) => {
 				if (run.kind === "psalmTitle") {
 					return (
 						<span key={`st-${runIdx}`} className={styles.psalmTitle}>
@@ -181,6 +202,7 @@ export default function TypesetChapter({
 						key={`pr-${runIdx}`}
 						input={run.input}
 						verseNumbers={run.verseNumbers}
+						containerWidth={containerWidth}
 						containerEl={chapterEl}
 						handlers={handlers}
 					/>

--- a/components/Reader/index.tsx
+++ b/components/Reader/index.tsx
@@ -6,6 +6,16 @@ import { useBibleContent } from "../../utils/useReadingPosition";
 import VerseDetails from "../VerseDetails";
 import type { ReaderProps, Bookmark } from "../../types/bible";
 import BibleStorageInstance from "../../utils/BibleStorage";
+import TypesetChapter from "./TypesetChapter";
+
+function buildCssSelectors(ids: string[]): string {
+	return ids
+		.flatMap((id) => [
+			`#${CSS.escape(id)}`,
+			`[data-verse-id="${CSS.escape(id)}"]`,
+		])
+		.join(", ");
+}
 
 function Reader({
 	book,
@@ -31,6 +41,24 @@ function Reader({
 		verse: string;
 		text: string;
 	} | null>(null);
+
+	const [optimalJustification, setOptimalJustification] = useState(false);
+
+	useEffect(() => {
+		BibleStorageInstance.getPreference("optimalJustification", false).then(
+			(val) => setOptimalJustification(val),
+		);
+
+		const handleToggle = () => {
+			BibleStorageInstance.getPreference("optimalJustification", false).then(
+				(val) => setOptimalJustification(val),
+			);
+		};
+		window.addEventListener("optimalJustificationChanged", handleToggle);
+		return () => {
+			window.removeEventListener("optimalJustificationChanged", handleToggle);
+		};
+	}, []);
 
 	useEffect(() => {
 		searchActiveRef.current = searchActive;
@@ -63,15 +91,15 @@ function Reader({
 			}
 
 			// Build CSS selectors for all red letter verses in this book
-			const selectors: string[] = [];
+			const ids: string[] = [];
 			for (const [chapter, verses] of Object.entries(record.chapters)) {
 				for (const verse of verses) {
-					selectors.push(`#${CSS.escape(`${chapter}:${verse}`)}`);
+					ids.push(`${chapter}:${verse}`);
 				}
 			}
 
-			styleEl.textContent = selectors.length
-				? `${selectors.join(", ")} { color: #c0392b; }`
+			styleEl.textContent = ids.length
+				? `${buildCssSelectors(ids)} { color: #c0392b; }`
 				: "";
 		};
 
@@ -106,12 +134,10 @@ function Reader({
 			}
 
 			// Generate CSS rules targeting bookmarked verse IDs
-			const selectors = bookmarkedVerses
-				.map((b) => `#${CSS.escape(`${b.chapter}:${b.verse}`)}`)
-				.join(", ");
+			const ids = bookmarkedVerses.map((b) => `${b.chapter}:${b.verse}`);
 
-			styleEl.textContent = selectors
-				? `${selectors} { background: rgba(255, 200, 0, 0.15); border-bottom: 2px solid rgba(255, 200, 0, 0.5); }`
+			styleEl.textContent = ids.length
+				? `${buildCssSelectors(ids)} { background: rgba(255, 200, 0, 0.15); border-bottom: 2px solid rgba(255, 200, 0, 0.5); }`
 				: "";
 		};
 
@@ -263,15 +289,17 @@ function Reader({
 			{ root: null, threshold: [0, 0.5, 1] }
 		);
 
-		const verses = document.querySelectorAll("p.verse");
-		verses.forEach((node) => observer.observe(node));
+		const verses = document.querySelectorAll("p.verse, .verseAnchor");
+		verses.forEach((node) => {
+			if ((node as HTMLElement).id) observer.observe(node);
+		});
 
 		const visibleIds = visibleIdsRef.current;
 		return () => {
 			observer.disconnect();
 			visibleIds.clear();
 		};
-	}, [book, onChapterChange]);
+	}, [book, onChapterChange, optimalJustification]);
 
 	const chaptersCount = book?.chapters.length || 0;
 
@@ -343,12 +371,10 @@ function Reader({
 			const bookmarkedVerses = bookmarks.filter((b) => b.book === book.book);
 
 			// Update CSS rules
-			const selectors = bookmarkedVerses
-				.map((b) => `#${CSS.escape(`${b.chapter}:${b.verse}`)}`)
-				.join(", ");
+			const ids = bookmarkedVerses.map((b) => `${b.chapter}:${b.verse}`);
 
-			styleEl.textContent = selectors
-				? `${selectors} { background: rgba(255, 200, 0, 0.15); border-bottom: 2px solid rgba(255, 200, 0, 0.5); }`
+			styleEl.textContent = ids.length
+				? `${buildCssSelectors(ids)} { background: rgba(255, 200, 0, 0.15); border-bottom: 2px solid rgba(255, 200, 0, 0.5); }`
 				: "";
 		}
 	}, [book]);
@@ -358,6 +384,24 @@ function Reader({
 		// Reload bookmarks after drawer closes (in case bookmark was added/removed)
 		await updateBookmarkStyles();
 	};
+
+	const handlePointerDown = useCallback((e: React.PointerEvent) => {
+		pointerStartRef.current = { x: e.clientX, y: e.clientY };
+	}, []);
+
+	const handlePointerUpNative = useCallback(
+		(e: React.PointerEvent, chapter: string, verse: string, text: string) => {
+			const start = pointerStartRef.current;
+			pointerStartRef.current = null;
+			if (!start) return;
+			const dx = Math.abs(e.clientX - start.x);
+			const dy = Math.abs(e.clientY - start.y);
+			if (dx > 10 || dy > 10) return;
+			handleVerseClick(chapter, verse, text);
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[book.book],
+	);
 
 	return (
 		<>
@@ -369,64 +413,78 @@ function Reader({
 			>
 				<div className={styles.book}>
 					<h1 className={styles.bookTitle}>{book.book}</h1>
-					{book.chapters?.map((chapter) => (
-						<div
-							key={chapter.chapter}
-							className={`${styles.chapter} ${book.book === "Psalms" ? styles.psalm : ""}`}
-							id={chapter.chapter.toString()}
-						>
-							<h2 className={styles.chapterNumber}>
-								{chaptersCount > 1
-									? chapter.chapter
-									: chapter.verses[0]?.text.slice(0, 1)}
-							</h2>
-							{chapter.title && (
-								<span className={styles.psalmTitle}>
-									{chapter.title}
-								</span>
-							)}
-							{chapter.verses.map((verse, i) => (
-								<p
-									key={verse.verse}
-									id={chapter.chapter + `:` + verse.verse}
-									className={`${styles.verse} verse ${
-										verse.paragraph ? styles.newParagraph : ""
-									} ${verse.poetry ? styles.poetry : ""} ${
-										highlightVerse &&
-										highlightVerse === chapter.chapter + `:` + verse.verse
-											? styles.selected
-											: ""
-									} ${
-										readingVerse === chapter.chapter + `:` + verse.verse
-											? styles.reading
-											: ""
-									} ${
-										selectedVerse &&
-										selectedVerse.chapter === chapter.chapter &&
-										selectedVerse.verse === verse.verse
-											? styles.selected
-											: ""
-									}`}
-									onPointerDown={(e) => {
-										pointerStartRef.current = { x: e.clientX, y: e.clientY };
-									}}
-									onPointerUp={(e) => {
-										const start = pointerStartRef.current;
-										pointerStartRef.current = null;
-										if (!start) return;
-										const dx = Math.abs(e.clientX - start.x);
-										const dy = Math.abs(e.clientY - start.y);
-										if (dx > 10 || dy > 10) return;
-										handleVerseClick(chapter.chapter, verse.verse, verse.text);
-									}}
-								>
-									<sup>{verse.verse}&nbsp;</sup>
-									{i === 0 && chaptersCount < 2 && verse.text.slice(1)}
-									{(i > 0 || chaptersCount > 1) && verse.text}
-								</p>
-							))}
-						</div>
-					))}
+					{book.chapters?.map((chapter) =>
+						optimalJustification ? (
+							<TypesetChapter
+								key={chapter.chapter}
+								chapter={chapter}
+								bookName={book.book}
+								chaptersCount={chaptersCount}
+								highlightVerse={highlightVerse}
+								readingVerse={readingVerse ?? null}
+								selectedVerse={selectedVerse}
+								onPointerDown={handlePointerDown}
+								onVerseClick={handleVerseClick}
+							/>
+						) : (
+							<div
+								key={chapter.chapter}
+								className={`${styles.chapter} ${book.book === "Psalms" ? styles.psalm : ""}`}
+								id={chapter.chapter.toString()}
+							>
+								<h2 className={styles.chapterNumber}>
+									{chaptersCount > 1
+										? chapter.chapter
+										: chapter.verses[0]?.text.slice(0, 1)}
+								</h2>
+								{chapter.title && (
+									<span className={styles.psalmTitle}>
+										{chapter.title}
+									</span>
+								)}
+								{chapter.verses.map((verse, i) => (
+									<p
+										key={verse.verse}
+										id={chapter.chapter + `:` + verse.verse}
+										className={`${styles.verse} verse ${
+											verse.paragraph ? styles.newParagraph : ""
+										} ${verse.poetry ? styles.poetry : ""} ${
+											highlightVerse &&
+											highlightVerse === chapter.chapter + `:` + verse.verse
+												? styles.selected
+												: ""
+										} ${
+											readingVerse === chapter.chapter + `:` + verse.verse
+												? styles.reading
+												: ""
+										} ${
+											selectedVerse &&
+											selectedVerse.chapter === chapter.chapter &&
+											selectedVerse.verse === verse.verse
+												? styles.selected
+												: ""
+										}`}
+										onPointerDown={(e) => {
+											pointerStartRef.current = { x: e.clientX, y: e.clientY };
+										}}
+										onPointerUp={(e) => {
+											const start = pointerStartRef.current;
+											pointerStartRef.current = null;
+											if (!start) return;
+											const dx = Math.abs(e.clientX - start.x);
+											const dy = Math.abs(e.clientY - start.y);
+											if (dx > 10 || dy > 10) return;
+											handleVerseClick(chapter.chapter, verse.verse, verse.text);
+										}}
+									>
+										<sup>{verse.verse}&nbsp;</sup>
+										{i === 0 && chaptersCount < 2 && verse.text.slice(1)}
+										{(i > 0 || chaptersCount > 1) && verse.text}
+									</p>
+								))}
+							</div>
+						),
+					)}
 				</div>
 			</div>
 

--- a/components/Reader/index.tsx
+++ b/components/Reader/index.tsx
@@ -385,24 +385,6 @@ function Reader({
 		await updateBookmarkStyles();
 	};
 
-	const handlePointerDown = useCallback((e: React.PointerEvent) => {
-		pointerStartRef.current = { x: e.clientX, y: e.clientY };
-	}, []);
-
-	const handlePointerUpNative = useCallback(
-		(e: React.PointerEvent, chapter: string, verse: string, text: string) => {
-			const start = pointerStartRef.current;
-			pointerStartRef.current = null;
-			if (!start) return;
-			const dx = Math.abs(e.clientX - start.x);
-			const dy = Math.abs(e.clientY - start.y);
-			if (dx > 10 || dy > 10) return;
-			handleVerseClick(chapter, verse, text);
-		},
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[book.book],
-	);
-
 	return (
 		<>
 			<div
@@ -423,7 +405,6 @@ function Reader({
 								highlightVerse={highlightVerse}
 								readingVerse={readingVerse ?? null}
 								selectedVerse={selectedVerse}
-								onPointerDown={handlePointerDown}
 								onVerseClick={handleVerseClick}
 							/>
 						) : (

--- a/components/Reader/index.tsx
+++ b/components/Reader/index.tsx
@@ -469,6 +469,19 @@ function Reader({
 				</div>
 			</div>
 
+			<button
+				className={styles.justificationToggle}
+				onClick={async () => {
+					const newValue = !optimalJustification;
+					setOptimalJustification(newValue);
+					await BibleStorageInstance.savePreference("optimalJustification", newValue);
+					window.dispatchEvent(new Event("optimalJustificationChanged"));
+				}}
+				aria-label="Toggle justification"
+			>
+				{optimalJustification ? "KP" : "CSS"}
+			</button>
+
 			<VerseDetails
 				active={selectedVerse !== null}
 				book={selectedVerse?.book || ""}

--- a/components/Settings/Settings.module.css
+++ b/components/Settings/Settings.module.css
@@ -54,6 +54,14 @@
 	font-weight: 300;
 }
 
+.settingDescription {
+	display: block;
+	font-size: 13px;
+	font-weight: 400;
+	opacity: 0.4;
+	margin-top: 2px;
+}
+
 .toggleIndicator {
 	width: 36px;
 	height: 20px;

--- a/components/Settings/index.tsx
+++ b/components/Settings/index.tsx
@@ -13,6 +13,7 @@ export default function Settings() {
 	const router = useRouter();
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const [redLetterEnabled, setRedLetterEnabled] = useState(true);
+	const [optimalJustification, setOptimalJustification] = useState(false);
 	const [playbackSpeed, setPlaybackSpeed] = useState(1);
 	const [isSamplePlaying, setIsSamplePlaying] = useState(false);
 	const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -23,6 +24,9 @@ export default function Settings() {
 	useEffect(() => {
 		BibleStorageInstance.getPreference("redLetterEnabled", true).then(
 			(val) => setRedLetterEnabled(val)
+		);
+		BibleStorageInstance.getPreference("optimalJustification", false).then(
+			(val) => setOptimalJustification(val)
 		);
 		BibleStorageInstance.getPreference("playbackSpeed", 1).then((val) =>
 			setPlaybackSpeed(val)
@@ -45,6 +49,13 @@ export default function Settings() {
 		setRedLetterEnabled(newValue);
 		await BibleStorageInstance.savePreference("redLetterEnabled", newValue);
 		window.dispatchEvent(new Event("redLetterChanged"));
+	};
+
+	const handleJustificationToggle = async () => {
+		const newValue = !optimalJustification;
+		setOptimalJustification(newValue);
+		await BibleStorageInstance.savePreference("optimalJustification", newValue);
+		window.dispatchEvent(new Event("optimalJustificationChanged"));
 	};
 
 	const handleSpeedChange = async (speed: number) => {
@@ -165,6 +176,19 @@ export default function Settings() {
 						className={styles.toggleIndicator}
 						data-enabled={redLetterEnabled}
 						onClick={handleRedLetterToggle}
+					/>
+				</div>
+				<div className={styles.settingRow}>
+					<div>
+						<span className={styles.settingLabel}>Optimal Justification</span>
+						<span className={styles.settingDescription}>
+							Experimental — Knuth–Plass line breaking
+						</span>
+					</div>
+					<span
+						className={styles.toggleIndicator}
+						data-enabled={optimalJustification}
+						onClick={handleJustificationToggle}
 					/>
 				</div>
 			</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
 				"@types/react-dom": "^18.3.1",
 				"eslint": "^9.17.0",
 				"eslint-config-next": "^15.1.6",
+				"hyphen": "^1.14.1",
 				"motion": "^12.25.0",
 				"next": "^15.1.6",
 				"react": "^18.3.1",
@@ -4513,6 +4514,12 @@
 			"engines": {
 				"node": ">=16.17.0"
 			}
+		},
+		"node_modules/hyphen": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.14.1.tgz",
+			"integrity": "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==",
+			"license": "ISC"
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "nextjs-app",
 			"version": "0.1.0",
 			"dependencies": {
+				"@chenglou/pretext": "^0.0.7",
 				"@mantine/core": "^8.3.12",
 				"@mantine/hooks": "^8.3.12",
 				"@tabler/icons-react": "^3.36.1",
@@ -365,6 +366,12 @@
 			"engines": {
 				"node": ">=6.9.0"
 			}
+		},
+		"node_modules/@chenglou/pretext": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.7.tgz",
+			"integrity": "sha512-FV5hj3fGqpBlzbANUbR+s+6XuNRrghVVyuNs33zdH2SzU7MvK+7GlW6xREjDCreixKbexEn7OEkDgAFeWuu5Hg==",
+			"license": "MIT"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.27.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"add-paragraphs": "node scripts/addParagraphBreaks.mjs"
 	},
 	"dependencies": {
+		"@chenglou/pretext": "^0.0.7",
 		"@mantine/core": "^8.3.12",
 		"@mantine/hooks": "^8.3.12",
 		"@tabler/icons-react": "^3.36.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"@types/react-dom": "^18.3.1",
 		"eslint": "^9.17.0",
 		"eslint-config-next": "^15.1.6",
+		"hyphen": "^1.14.1",
 		"motion": "^12.25.0",
 		"next": "^15.1.6",
 		"react": "^18.3.1",

--- a/utils/typeset/hyphen-en.d.ts
+++ b/utils/typeset/hyphen-en.d.ts
@@ -1,0 +1,4 @@
+declare module "hyphen/en" {
+	export function hyphenateSync(text: string, options?: { hyphenChar?: string; minWordLength?: number }): string;
+	export function hyphenate(text: string, options?: { hyphenChar?: string; minWordLength?: number }): Promise<string>;
+}

--- a/utils/typeset/hyphenate.test.ts
+++ b/utils/typeset/hyphenate.test.ts
@@ -2,42 +2,44 @@ import { describe, it, expect } from "vitest";
 import { hyphenateText, SOFT_HYPHEN } from "./hyphenate";
 
 describe("hyphenate", () => {
-	it("does not hyphenate short words", () => {
-		expect(hyphenateText("the and but")).toBe("the and but");
+	it("does not hyphenate short words", async () => {
+		const result = await hyphenateText("the and but");
+		expect(result).toBe("the and but");
 	});
 
-	it("hyphenates words with known prefixes", () => {
-		const result = hyphenateText("unbroken");
-		expect(result).toContain(SOFT_HYPHEN);
-		expect(result).toBe(`un${SOFT_HYPHEN}broken`);
-	});
-
-	it("hyphenates words with known suffixes", () => {
-		const result = hyphenateText("righteous");
-		expect(result).toContain(SOFT_HYPHEN);
-		expect(result).toBe(`righte${SOFT_HYPHEN}ous`);
-	});
-
-	it("preserves whitespace", () => {
-		const result = hyphenateText("hello  world");
-		expect(result).toBe("hello  world");
-	});
-
-	it("does not hyphenate words shorter than 5 chars", () => {
-		expect(hyphenateText("able")).toBe("able");
-	});
-
-	it("handles punctuation gracefully", () => {
-		const result = hyphenateText("unbroken,");
+	it("hyphenates multi-syllable words", async () => {
+		const result = await hyphenateText("righteousness");
 		expect(result).toContain(SOFT_HYPHEN);
 	});
 
-	it("handles empty string", () => {
-		expect(hyphenateText("")).toBe("");
+	it("preserves whitespace", async () => {
+		const result = await hyphenateText("the  Lord");
+		expect(result).toBe("the  Lord");
 	});
 
-	it("handles single word", () => {
-		const result = hyphenateText("understanding");
+	it("handles empty string", async () => {
+		expect(await hyphenateText("")).toBe("");
+	});
+
+	it("handles KJV vocabulary correctly", async () => {
+		const result = await hyphenateText("abomination");
 		expect(result).toContain(SOFT_HYPHEN);
+		const parts = result.split(SOFT_HYPHEN);
+		expect(parts.length).toBeGreaterThan(1);
+		expect(parts.join("")).toBe("abomination");
+	});
+
+	it("handles commandments", async () => {
+		const result = await hyphenateText("commandments");
+		expect(result).toContain(SOFT_HYPHEN);
+	});
+
+	it("handles mixed text with punctuation", async () => {
+		const result = await hyphenateText("In the beginning God created the heaven and the earth.");
+		expect(result).toContain(SOFT_HYPHEN);
+		// The soft hyphens should be in longer words like "beginning", "created"
+		expect(result.replace(new RegExp(SOFT_HYPHEN, "g"), "")).toBe(
+			"In the beginning God created the heaven and the earth."
+		);
 	});
 });

--- a/utils/typeset/hyphenate.test.ts
+++ b/utils/typeset/hyphenate.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { hyphenateText, SOFT_HYPHEN } from "./hyphenate";
+
+describe("hyphenate", () => {
+	it("does not hyphenate short words", () => {
+		expect(hyphenateText("the and but")).toBe("the and but");
+	});
+
+	it("hyphenates words with known prefixes", () => {
+		const result = hyphenateText("unbroken");
+		expect(result).toContain(SOFT_HYPHEN);
+		expect(result).toBe(`un${SOFT_HYPHEN}broken`);
+	});
+
+	it("hyphenates words with known suffixes", () => {
+		const result = hyphenateText("righteous");
+		expect(result).toContain(SOFT_HYPHEN);
+		expect(result).toBe(`righte${SOFT_HYPHEN}ous`);
+	});
+
+	it("preserves whitespace", () => {
+		const result = hyphenateText("hello  world");
+		expect(result).toBe("hello  world");
+	});
+
+	it("does not hyphenate words shorter than 5 chars", () => {
+		expect(hyphenateText("able")).toBe("able");
+	});
+
+	it("handles punctuation gracefully", () => {
+		const result = hyphenateText("unbroken,");
+		expect(result).toContain(SOFT_HYPHEN);
+	});
+
+	it("handles empty string", () => {
+		expect(hyphenateText("")).toBe("");
+	});
+
+	it("handles single word", () => {
+		const result = hyphenateText("understanding");
+		expect(result).toContain(SOFT_HYPHEN);
+	});
+});

--- a/utils/typeset/hyphenate.ts
+++ b/utils/typeset/hyphenate.ts
@@ -1,53 +1,27 @@
 const SOFT_HYPHEN = "­";
 
-const PREFIXES = [
-	"anti", "auto", "be", "bi", "co", "com", "con", "contra", "counter", "de",
-	"dis", "en", "em", "ex", "extra", "fore", "hyper", "il", "im", "in", "inter",
-	"intra", "ir", "macro", "mal", "micro", "mid", "mis", "mono", "multi", "non",
-	"omni", "out", "over", "para", "poly", "post", "pre", "pro", "pseudo",
-	"quasi", "re", "retro", "semi", "sub", "super", "sur", "syn", "tele", "trans",
-	"tri", "ultra", "un", "under",
-];
+let hyphenateFn: ((text: string) => string) | null = null;
+let loadPromise: Promise<void> | null = null;
 
-const SUFFIXES = [
-	"able", "ible", "tion", "sion", "ment", "ness", "ous", "ious", "eous", "ful",
-	"less", "ive", "ative", "itive", "al", "ial", "ical", "ing", "ling",
-	"ed", "er", "est", "ism", "ist", "ity", "ety", "ty", "ence", "ance", "ly",
-	"fy", "ify", "ize", "ise", "ure", "ture",
-];
-
-function hyphenateWord(word: string): string[] {
-	const lower = word.toLowerCase().replace(/[.,;:!?"'—–\-()[\]]/g, "");
-	if (lower.length < 5) return [word];
-
-	for (const prefix of PREFIXES) {
-		if (lower.startsWith(prefix) && lower.length - prefix.length >= 3) {
-			return [word.slice(0, prefix.length), word.slice(prefix.length)];
-		}
+async function ensureLoaded(): Promise<void> {
+	if (hyphenateFn) return;
+	if (!loadPromise) {
+		loadPromise = import("hyphen/en").then((mod) => {
+			hyphenateFn = mod.hyphenateSync;
+		});
 	}
-
-	for (const suffix of SUFFIXES) {
-		if (lower.endsWith(suffix) && lower.length - suffix.length >= 3) {
-			const cut = word.length - suffix.length;
-			return [word.slice(0, cut), word.slice(cut)];
-		}
-	}
-
-	return [word];
+	return loadPromise;
 }
 
-export function hyphenateText(text: string): string {
-	const tokens = text.split(/(\s+)/);
-	let result = "";
-	for (const token of tokens) {
-		if (/^\s+$/.test(token)) {
-			result += token;
-			continue;
-		}
-		const parts = hyphenateWord(token);
-		result += parts.length <= 1 ? token : parts.join(SOFT_HYPHEN);
-	}
-	return result;
+export async function hyphenateText(text: string): Promise<string> {
+	await ensureLoaded();
+	if (!hyphenateFn) return text;
+	return hyphenateFn(text);
+}
+
+export function hyphenateTextSync(text: string): string {
+	if (!hyphenateFn) return text;
+	return hyphenateFn(text);
 }
 
 export { SOFT_HYPHEN };

--- a/utils/typeset/hyphenate.ts
+++ b/utils/typeset/hyphenate.ts
@@ -1,0 +1,53 @@
+const SOFT_HYPHEN = "­";
+
+const PREFIXES = [
+	"anti", "auto", "be", "bi", "co", "com", "con", "contra", "counter", "de",
+	"dis", "en", "em", "ex", "extra", "fore", "hyper", "il", "im", "in", "inter",
+	"intra", "ir", "macro", "mal", "micro", "mid", "mis", "mono", "multi", "non",
+	"omni", "out", "over", "para", "poly", "post", "pre", "pro", "pseudo",
+	"quasi", "re", "retro", "semi", "sub", "super", "sur", "syn", "tele", "trans",
+	"tri", "ultra", "un", "under",
+];
+
+const SUFFIXES = [
+	"able", "ible", "tion", "sion", "ment", "ness", "ous", "ious", "eous", "ful",
+	"less", "ive", "ative", "itive", "al", "ial", "ical", "ing", "ling",
+	"ed", "er", "est", "ism", "ist", "ity", "ety", "ty", "ence", "ance", "ly",
+	"fy", "ify", "ize", "ise", "ure", "ture",
+];
+
+function hyphenateWord(word: string): string[] {
+	const lower = word.toLowerCase().replace(/[.,;:!?"'—–\-()[\]]/g, "");
+	if (lower.length < 5) return [word];
+
+	for (const prefix of PREFIXES) {
+		if (lower.startsWith(prefix) && lower.length - prefix.length >= 3) {
+			return [word.slice(0, prefix.length), word.slice(prefix.length)];
+		}
+	}
+
+	for (const suffix of SUFFIXES) {
+		if (lower.endsWith(suffix) && lower.length - suffix.length >= 3) {
+			const cut = word.length - suffix.length;
+			return [word.slice(0, cut), word.slice(cut)];
+		}
+	}
+
+	return [word];
+}
+
+export function hyphenateText(text: string): string {
+	const tokens = text.split(/(\s+)/);
+	let result = "";
+	for (const token of tokens) {
+		if (/^\s+$/.test(token)) {
+			result += token;
+			continue;
+		}
+		const parts = hyphenateWord(token);
+		result += parts.length <= 1 ? token : parts.join(SOFT_HYPHEN);
+	}
+	return result;
+}
+
+export { SOFT_HYPHEN };

--- a/utils/typeset/knuthPlass.test.ts
+++ b/utils/typeset/knuthPlass.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { breakParagraph, _lineBadness, _getLineStats } from "./knuthPlass";
+import type { PreparedTextWithSegments } from "@chenglou/pretext";
+
+function makePrepared(words: string[], wordWidth: number, spaceWidth: number): PreparedTextWithSegments {
+	const segments: string[] = [];
+	const widths: number[] = [];
+
+	for (let i = 0; i < words.length; i++) {
+		if (i > 0) {
+			segments.push(" ");
+			widths.push(spaceWidth);
+		}
+		segments.push(words[i]!);
+		widths.push(wordWidth);
+	}
+
+	return {
+		segments,
+		widths,
+	} as unknown as PreparedTextWithSegments;
+}
+
+describe("knuthPlass", () => {
+	describe("breakParagraph", () => {
+		it("returns empty array for empty input", () => {
+			const prepared = { segments: [], widths: [] } as unknown as PreparedTextWithSegments;
+			const result = breakParagraph(prepared, [], 200, { normalSpaceWidth: 5 });
+			expect(result).toEqual([]);
+		});
+
+		it("keeps single-line paragraph on one line", () => {
+			const prepared = makePrepared(["Hello", "world"], 30, 5);
+			const verseMap = [{ start: 0, end: 11, verseId: "1:1" }];
+			const result = breakParagraph(prepared, verseMap, 200, { normalSpaceWidth: 5 });
+			expect(result).toHaveLength(1);
+			expect(result[0]!.isLast).toBe(true);
+			expect(result[0]!.spacing.kind).toBe("ragged");
+		});
+
+		it("breaks long text into multiple lines", () => {
+			const words = Array.from({ length: 20 }, (_, i) => `word${i}`);
+			const prepared = makePrepared(words, 40, 5);
+			const verseMap = [{ start: 0, end: words.join(" ").length, verseId: "1:1" }];
+			const result = breakParagraph(prepared, verseMap, 200, { normalSpaceWidth: 5 });
+
+			expect(result.length).toBeGreaterThan(1);
+
+			const lastLine = result[result.length - 1]!;
+			expect(lastLine.isLast).toBe(true);
+			expect(lastLine.spacing.kind).toBe("ragged");
+
+			for (let i = 0; i < result.length - 1; i++) {
+				const line = result[i]!;
+				expect(line.spacing.kind).not.toBe("ragged");
+			}
+		});
+
+		it("justifies non-last lines", () => {
+			const words = Array.from({ length: 10 }, () => "test");
+			const prepared = makePrepared(words, 30, 5);
+			const verseMap = [{ start: 0, end: words.join(" ").length, verseId: "1:1" }];
+			const result = breakParagraph(prepared, verseMap, 150, { normalSpaceWidth: 5 });
+
+			expect(result.length).toBeGreaterThan(1);
+			const firstLine = result[0]!;
+			if (firstLine.spacing.kind === "justified") {
+				expect(typeof firstLine.spacing.wordSpacingPx).toBe("number");
+			}
+		});
+
+		it("assigns correct verse IDs across multiple verses", () => {
+			const text = "Hello world. Goodbye now.";
+			const prepared = makePrepared(["Hello", "world.", "Goodbye", "now."], 40, 5);
+			const verseMap = [
+				{ start: 0, end: 12, verseId: "1:1" },
+				{ start: 13, end: 25, verseId: "1:2" },
+			];
+			const result = breakParagraph(prepared, verseMap, 200, { normalSpaceWidth: 5 });
+
+			const allVerseIds = result.flatMap((l) => l.verseIds);
+			expect(allVerseIds).toContain("1:1");
+			expect(allVerseIds).toContain("1:2");
+		});
+
+		it("handles very narrow width gracefully", () => {
+			const prepared = makePrepared(["Supercalifragilistic"], 200, 5);
+			const verseMap = [{ start: 0, end: 20, verseId: "1:1" }];
+			const result = breakParagraph(prepared, verseMap, 50, { normalSpaceWidth: 5 });
+			expect(result.length).toBeGreaterThanOrEqual(1);
+		});
+	});
+
+	describe("lineBadness", () => {
+		it("returns 0 for last line that fits", () => {
+			const stats = { wordWidth: 100, spaceCount: 3, naturalWidth: 115 };
+			const badness = _lineBadness(stats, 200, 5, true);
+			expect(badness).toBe(0);
+		});
+
+		it("returns HUGE_BADNESS for overflowing last line", () => {
+			const stats = { wordWidth: 300, spaceCount: 0, naturalWidth: 300 };
+			const badness = _lineBadness(stats, 200, 5, true);
+			expect(badness).toBe(1e8);
+		});
+
+		it("penalizes tight spacing", () => {
+			const normalStats = { wordWidth: 140, spaceCount: 3, naturalWidth: 155 };
+			const normalBadness = _lineBadness(normalStats, 160, 5, false);
+
+			const tightStats = { wordWidth: 155, spaceCount: 3, naturalWidth: 170 };
+			const tightBadness = _lineBadness(tightStats, 160, 5, false);
+
+			expect(tightBadness).toBeGreaterThan(normalBadness);
+		});
+	});
+
+	describe("getLineStats", () => {
+		it("counts words and spaces correctly", () => {
+			const segments = ["hello", " ", "world", " ", "test"];
+			const widths = [30, 5, 35, 5, 25];
+			const candidates = [{ segIndex: 0 }, { segIndex: 2 }, { segIndex: 4 }, { segIndex: 5 }];
+			const stats = _getLineStats(segments, widths, candidates, 0, 3, 5);
+
+			expect(stats.wordWidth).toBe(90);
+			expect(stats.spaceCount).toBe(2);
+			expect(stats.naturalWidth).toBe(100);
+		});
+	});
+});

--- a/utils/typeset/knuthPlass.test.ts
+++ b/utils/typeset/knuthPlass.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import { breakParagraph, _lineBadness, _getLineStats } from "./knuthPlass";
 import type { PreparedTextWithSegments } from "@chenglou/pretext";
 
+const OPTS = { normalSpaceWidth: 5, hyphenWidth: 4 };
+
 function makePrepared(words: string[], wordWidth: number, spaceWidth: number): PreparedTextWithSegments {
 	const segments: string[] = [];
 	const widths: number[] = [];
@@ -25,14 +27,14 @@ describe("knuthPlass", () => {
 	describe("breakParagraph", () => {
 		it("returns empty array for empty input", () => {
 			const prepared = { segments: [], widths: [] } as unknown as PreparedTextWithSegments;
-			const result = breakParagraph(prepared, [], 200, { normalSpaceWidth: 5 });
+			const result = breakParagraph(prepared, [], 200, OPTS);
 			expect(result).toEqual([]);
 		});
 
 		it("keeps single-line paragraph on one line", () => {
 			const prepared = makePrepared(["Hello", "world"], 30, 5);
 			const verseMap = [{ start: 0, end: 11, verseId: "1:1" }];
-			const result = breakParagraph(prepared, verseMap, 200, { normalSpaceWidth: 5 });
+			const result = breakParagraph(prepared, verseMap, 200, OPTS);
 			expect(result).toHaveLength(1);
 			expect(result[0]!.isLast).toBe(true);
 			expect(result[0]!.spacing.kind).toBe("ragged");
@@ -42,7 +44,7 @@ describe("knuthPlass", () => {
 			const words = Array.from({ length: 20 }, (_, i) => `word${i}`);
 			const prepared = makePrepared(words, 40, 5);
 			const verseMap = [{ start: 0, end: words.join(" ").length, verseId: "1:1" }];
-			const result = breakParagraph(prepared, verseMap, 200, { normalSpaceWidth: 5 });
+			const result = breakParagraph(prepared, verseMap, 200, OPTS);
 
 			expect(result.length).toBeGreaterThan(1);
 
@@ -60,7 +62,7 @@ describe("knuthPlass", () => {
 			const words = Array.from({ length: 10 }, () => "test");
 			const prepared = makePrepared(words, 30, 5);
 			const verseMap = [{ start: 0, end: words.join(" ").length, verseId: "1:1" }];
-			const result = breakParagraph(prepared, verseMap, 150, { normalSpaceWidth: 5 });
+			const result = breakParagraph(prepared, verseMap, 150, OPTS);
 
 			expect(result.length).toBeGreaterThan(1);
 			const firstLine = result[0]!;
@@ -70,13 +72,12 @@ describe("knuthPlass", () => {
 		});
 
 		it("assigns correct verse IDs across multiple verses", () => {
-			const text = "Hello world. Goodbye now.";
 			const prepared = makePrepared(["Hello", "world.", "Goodbye", "now."], 40, 5);
 			const verseMap = [
 				{ start: 0, end: 12, verseId: "1:1" },
 				{ start: 13, end: 25, verseId: "1:2" },
 			];
-			const result = breakParagraph(prepared, verseMap, 200, { normalSpaceWidth: 5 });
+			const result = breakParagraph(prepared, verseMap, 200, OPTS);
 
 			const allVerseIds = result.flatMap((l) => l.verseIds);
 			expect(allVerseIds).toContain("1:1");
@@ -86,32 +87,62 @@ describe("knuthPlass", () => {
 		it("handles very narrow width gracefully", () => {
 			const prepared = makePrepared(["Supercalifragilistic"], 200, 5);
 			const verseMap = [{ start: 0, end: 20, verseId: "1:1" }];
-			const result = breakParagraph(prepared, verseMap, 50, { normalSpaceWidth: 5 });
+			const result = breakParagraph(prepared, verseMap, 50, OPTS);
 			expect(result.length).toBeGreaterThanOrEqual(1);
+		});
+
+		it("can break at soft hyphens", () => {
+			const SOFT_HYPHEN = "­";
+			const segments = ["justifi", SOFT_HYPHEN, "cation"];
+			const widths = [40, 0, 35];
+			const prepared = { segments, widths } as unknown as PreparedTextWithSegments;
+			const verseMap = [{ start: 0, end: 14, verseId: "1:1" }];
+			const result = breakParagraph(prepared, verseMap, 50, OPTS);
+			expect(result.length).toBeGreaterThanOrEqual(1);
+			const allText = result.flatMap(l => l.segments.filter(s => s.kind === "text").map(s => (s as any).text)).join("");
+			expect(allText).toContain("-");
+		});
+
+		it("tracks charStartOffset correctly", () => {
+			const words = Array.from({ length: 10 }, () => "word");
+			const prepared = makePrepared(words, 40, 5);
+			const verseMap = [{ start: 0, end: words.join(" ").length, verseId: "1:1" }];
+			const result = breakParagraph(prepared, verseMap, 200, OPTS);
+
+			expect(result[0]!.charStartOffset).toBe(0);
+			if (result.length > 1) {
+				expect(result[1]!.charStartOffset).toBeGreaterThan(0);
+			}
 		});
 	});
 
 	describe("lineBadness", () => {
 		it("returns 0 for last line that fits", () => {
-			const stats = { wordWidth: 100, spaceCount: 3, naturalWidth: 115 };
+			const stats = { wordWidth: 100, spaceCount: 3, naturalWidth: 115, trailingHyphen: false };
 			const badness = _lineBadness(stats, 200, 5, true);
 			expect(badness).toBe(0);
 		});
 
 		it("returns HUGE_BADNESS for overflowing last line", () => {
-			const stats = { wordWidth: 300, spaceCount: 0, naturalWidth: 300 };
+			const stats = { wordWidth: 300, spaceCount: 0, naturalWidth: 300, trailingHyphen: false };
 			const badness = _lineBadness(stats, 200, 5, true);
 			expect(badness).toBe(1e8);
 		});
 
 		it("penalizes tight spacing", () => {
-			const normalStats = { wordWidth: 140, spaceCount: 3, naturalWidth: 155 };
+			const normalStats = { wordWidth: 140, spaceCount: 3, naturalWidth: 155, trailingHyphen: false };
 			const normalBadness = _lineBadness(normalStats, 160, 5, false);
 
-			const tightStats = { wordWidth: 155, spaceCount: 3, naturalWidth: 170 };
+			const tightStats = { wordWidth: 155, spaceCount: 3, naturalWidth: 170, trailingHyphen: false };
 			const tightBadness = _lineBadness(tightStats, 160, 5, false);
 
 			expect(tightBadness).toBeGreaterThan(normalBadness);
+		});
+
+		it("adds penalty for trailing hyphen", () => {
+			const noHyphen = { wordWidth: 140, spaceCount: 3, naturalWidth: 155, trailingHyphen: false };
+			const withHyphen = { wordWidth: 140, spaceCount: 3, naturalWidth: 155, trailingHyphen: true };
+			expect(_lineBadness(withHyphen, 160, 5, false)).toBeGreaterThan(_lineBadness(noHyphen, 160, 5, false));
 		});
 	});
 
@@ -119,12 +150,31 @@ describe("knuthPlass", () => {
 		it("counts words and spaces correctly", () => {
 			const segments = ["hello", " ", "world", " ", "test"];
 			const widths = [30, 5, 35, 5, 25];
-			const candidates = [{ segIndex: 0 }, { segIndex: 2 }, { segIndex: 4 }, { segIndex: 5 }];
-			const stats = _getLineStats(segments, widths, candidates, 0, 3, 5);
+			const candidates = [
+				{ segIndex: 0, kind: "start" as const },
+				{ segIndex: 2, kind: "space" as const },
+				{ segIndex: 4, kind: "space" as const },
+				{ segIndex: 5, kind: "end" as const },
+			];
+			const stats = _getLineStats(segments, widths, candidates, 0, 3, 5, 4);
 
 			expect(stats.wordWidth).toBe(90);
 			expect(stats.spaceCount).toBe(2);
 			expect(stats.naturalWidth).toBe(100);
+		});
+
+		it("accounts for hyphen width at soft-hyphen breaks", () => {
+			const SOFT_HYPHEN = "­";
+			const segments = ["justi", SOFT_HYPHEN, "fi"];
+			const widths = [30, 0, 10];
+			const candidates = [
+				{ segIndex: 0, kind: "start" as const },
+				{ segIndex: 2, kind: "soft-hyphen" as const },
+				{ segIndex: 3, kind: "end" as const },
+			];
+			const stats = _getLineStats(segments, widths, candidates, 0, 1, 5, 4);
+			expect(stats.wordWidth).toBe(34); // 30 + 4 (hyphen)
+			expect(stats.trailingHyphen).toBe(true);
 		});
 	});
 });

--- a/utils/typeset/knuthPlass.ts
+++ b/utils/typeset/knuthPlass.ts
@@ -1,0 +1,284 @@
+import type { PreparedTextWithSegments } from "@chenglou/pretext";
+import type { VerseMapEntry, LineSegment, LineSpacing, PositionedLine } from "./types";
+import { getVerseIdAtOffset } from "./paragraphBuilder";
+
+const HUGE_BADNESS = 1e8;
+const SHORT_LINE_RATIO = 0.6;
+const RIVER_THRESHOLD = 1.5;
+const INFEASIBLE_SPACE_RATIO = 0.4;
+const OVERFLOW_SPACE_RATIO = 0.2;
+const TIGHT_SPACE_RATIO = 0.65;
+
+export interface BreakOptions {
+	normalSpaceWidth: number;
+}
+
+interface BreakCandidate {
+	segIndex: number;
+}
+
+interface LineStats {
+	wordWidth: number;
+	spaceCount: number;
+	naturalWidth: number;
+}
+
+function isSpaceText(text: string): boolean {
+	return text.trim().length === 0;
+}
+
+function getLineStats(
+	segments: readonly string[],
+	widths: readonly number[],
+	breakCandidates: readonly BreakCandidate[],
+	fromCandidate: number,
+	toCandidate: number,
+	normalSpaceWidth: number,
+): LineStats {
+	const from = breakCandidates[fromCandidate]!.segIndex;
+	const to = breakCandidates[toCandidate]!.segIndex;
+
+	let wordWidth = 0;
+	let spaceCount = 0;
+	for (let segIndex = from; segIndex < to; segIndex++) {
+		const text = segments[segIndex]!;
+		if (isSpaceText(text)) {
+			spaceCount++;
+		} else {
+			wordWidth += widths[segIndex]!;
+		}
+	}
+
+	if (to > from && isSpaceText(segments[to - 1]!)) {
+		spaceCount--;
+	}
+
+	return {
+		wordWidth,
+		spaceCount,
+		naturalWidth: wordWidth + spaceCount * normalSpaceWidth,
+	};
+}
+
+function lineBadness(
+	stats: LineStats,
+	maxWidth: number,
+	normalSpaceWidth: number,
+	isLastLine: boolean,
+): number {
+	if (isLastLine) {
+		if (stats.wordWidth > maxWidth) return HUGE_BADNESS;
+		return 0;
+	}
+
+	if (stats.spaceCount <= 0) {
+		const slack = maxWidth - stats.wordWidth;
+		if (slack < 0) return HUGE_BADNESS;
+		return slack * slack * 10;
+	}
+
+	const justifiedSpace = (maxWidth - stats.wordWidth) / stats.spaceCount;
+	if (justifiedSpace < 0) return HUGE_BADNESS;
+	if (justifiedSpace < normalSpaceWidth * INFEASIBLE_SPACE_RATIO) return HUGE_BADNESS;
+
+	const ratio = (justifiedSpace - normalSpaceWidth) / normalSpaceWidth;
+	const absRatio = Math.abs(ratio);
+	const badness = absRatio * absRatio * absRatio * 1000;
+
+	const riverExcess = justifiedSpace / normalSpaceWidth - RIVER_THRESHOLD;
+	const riverPenalty = riverExcess > 0
+		? 5000 + riverExcess * riverExcess * 10000
+		: 0;
+
+	const tightThreshold = normalSpaceWidth * TIGHT_SPACE_RATIO;
+	const tightPenalty = justifiedSpace < tightThreshold
+		? 3000 + (tightThreshold - justifiedSpace) * (tightThreshold - justifiedSpace) * 10000
+		: 0;
+
+	return badness + riverPenalty + tightPenalty;
+}
+
+export function breakParagraph(
+	prepared: PreparedTextWithSegments,
+	verseMap: VerseMapEntry[],
+	maxWidth: number,
+	opts: BreakOptions,
+): PositionedLine[] {
+	const segments = prepared.segments;
+	const widths = prepared.widths;
+	const segmentCount = segments.length;
+
+	if (segmentCount === 0) return [];
+
+	const breakCandidates: BreakCandidate[] = [{ segIndex: 0 }];
+	for (let segIndex = 0; segIndex < segmentCount; segIndex++) {
+		const text = segments[segIndex]!;
+		if (isSpaceText(text) && segIndex + 1 < segmentCount) {
+			breakCandidates.push({ segIndex: segIndex + 1 });
+		}
+	}
+	breakCandidates.push({ segIndex: segmentCount });
+
+	const candidateCount = breakCandidates.length;
+	const dp: number[] = new Array(candidateCount).fill(Infinity);
+	const previous: number[] = new Array(candidateCount).fill(-1);
+	dp[0] = 0;
+
+	for (let toCandidate = 1; toCandidate < candidateCount; toCandidate++) {
+		const isLastLine = toCandidate === candidateCount - 1;
+
+		for (let fromCandidate = toCandidate - 1; fromCandidate >= 0; fromCandidate--) {
+			if (dp[fromCandidate] === Infinity) continue;
+			const stats = getLineStats(
+				segments,
+				widths,
+				breakCandidates,
+				fromCandidate,
+				toCandidate,
+				opts.normalSpaceWidth,
+			);
+
+			if (stats.naturalWidth > maxWidth * 2) break;
+
+			const totalBadness = dp[fromCandidate]! + lineBadness(stats, maxWidth, opts.normalSpaceWidth, isLastLine);
+			if (totalBadness < dp[toCandidate]!) {
+				dp[toCandidate] = totalBadness;
+				previous[toCandidate] = fromCandidate;
+			}
+		}
+	}
+
+	// If DP couldn't find any valid path (e.g. single oversized word), use greedy fallback
+	if (dp[candidateCount - 1] === Infinity) {
+		const fallbackLines: PositionedLine[] = [];
+		let from = 0;
+		for (let to = 1; to < candidateCount; to++) {
+			fallbackLines.push(
+				buildLine(prepared, verseMap, breakCandidates, from, to, maxWidth, opts.normalSpaceWidth, to === candidateCount - 1),
+			);
+			from = to;
+		}
+		if (fallbackLines.length === 0 && candidateCount >= 2) {
+			fallbackLines.push(
+				buildLine(prepared, verseMap, breakCandidates, 0, candidateCount - 1, maxWidth, opts.normalSpaceWidth, true),
+			);
+		}
+		return fallbackLines;
+	}
+
+	const breakIndices: number[] = [];
+	let current = candidateCount - 1;
+	while (current > 0) {
+		if (previous[current] === -1) {
+			current--;
+			continue;
+		}
+		breakIndices.push(current);
+		current = previous[current]!;
+	}
+	breakIndices.reverse();
+
+	const lines: PositionedLine[] = [];
+	let fromCandidate = 0;
+
+	for (let idx = 0; idx < breakIndices.length; idx++) {
+		const toCandidate = breakIndices[idx]!;
+		const isLast = toCandidate === candidateCount - 1;
+		const line = buildLine(
+			prepared,
+			verseMap,
+			breakCandidates,
+			fromCandidate,
+			toCandidate,
+			maxWidth,
+			opts.normalSpaceWidth,
+			isLast,
+		);
+		lines.push(line);
+		fromCandidate = toCandidate;
+	}
+
+	return lines;
+}
+
+function buildLine(
+	prepared: PreparedTextWithSegments,
+	verseMap: VerseMapEntry[],
+	breakCandidates: readonly BreakCandidate[],
+	fromCandidate: number,
+	toCandidate: number,
+	maxWidth: number,
+	normalSpaceWidth: number,
+	isLast: boolean,
+): PositionedLine {
+	const from = breakCandidates[fromCandidate]!.segIndex;
+	const to = breakCandidates[toCandidate]!.segIndex;
+
+	const lineSegments: LineSegment[] = [];
+	let charOffset = 0;
+	for (let i = 0; i < from; i++) {
+		charOffset += prepared.segments[i]!.length;
+	}
+
+	const verseIdsSet = new Set<string>();
+	for (let segIndex = from; segIndex < to; segIndex++) {
+		const text = prepared.segments[segIndex]!;
+		const width = prepared.widths[segIndex]!;
+		const vid = getVerseIdAtOffset(verseMap, charOffset);
+
+		if (isSpaceText(text)) {
+			lineSegments.push({ kind: "space", width });
+		} else {
+			lineSegments.push({ kind: "text", text, width });
+			verseIdsSet.add(vid);
+		}
+
+		charOffset += text.length;
+	}
+
+	// Trim trailing spaces
+	while (lineSegments.length > 0 && lineSegments[lineSegments.length - 1]!.kind === "space") {
+		lineSegments.pop();
+	}
+
+	let wordWidth = 0;
+	let spaceCount = 0;
+	let naturalWidth = 0;
+	for (const seg of lineSegments) {
+		naturalWidth += seg.kind === "space" ? seg.width : seg.width;
+		if (seg.kind === "space") {
+			spaceCount++;
+		} else {
+			wordWidth += seg.width;
+		}
+	}
+	naturalWidth = wordWidth + spaceCount * normalSpaceWidth;
+
+	let spacing: LineSpacing;
+	if (isLast) {
+		spacing = { kind: "ragged" };
+	} else if (naturalWidth < maxWidth * SHORT_LINE_RATIO || spaceCount <= 0) {
+		spacing = { kind: "ragged" };
+	} else {
+		const rawJustifiedSpace = (maxWidth - wordWidth) / spaceCount;
+		if (rawJustifiedSpace < normalSpaceWidth * OVERFLOW_SPACE_RATIO) {
+			spacing = { kind: "overflow" };
+		} else {
+			const wordSpacingPx = rawJustifiedSpace - normalSpaceWidth;
+			spacing = { kind: "justified", wordSpacingPx };
+		}
+	}
+
+	return {
+		segments: lineSegments,
+		verseIds: Array.from(verseIdsSet),
+		spacing,
+		isLast,
+		wordWidth,
+		spaceCount,
+		naturalWidth,
+	};
+}
+
+// Re-export for testing
+export { lineBadness as _lineBadness, getLineStats as _getLineStats };

--- a/utils/typeset/knuthPlass.ts
+++ b/utils/typeset/knuthPlass.ts
@@ -241,7 +241,9 @@ function buildLine(
 	const lineSegments: LineSegment[] = [];
 	let charOffset = 0;
 	for (let i = 0; i < from; i++) {
-		charOffset += prepared.segments[i]!.length;
+		if (prepared.segments[i] !== SOFT_HYPHEN) {
+			charOffset += prepared.segments[i]!.length;
+		}
 	}
 	const charStartOffset = charOffset;
 
@@ -251,7 +253,6 @@ function buildLine(
 		const width = prepared.widths[segIndex]!;
 
 		if (text === SOFT_HYPHEN) {
-			charOffset += text.length;
 			continue;
 		}
 

--- a/utils/typeset/knuthPlass.ts
+++ b/utils/typeset/knuthPlass.ts
@@ -1,8 +1,10 @@
 import type { PreparedTextWithSegments } from "@chenglou/pretext";
 import type { VerseMapEntry, LineSegment, LineSpacing, PositionedLine } from "./types";
 import { getVerseIdAtOffset } from "./paragraphBuilder";
+import { SOFT_HYPHEN } from "./hyphenate";
 
 const HUGE_BADNESS = 1e8;
+const HYPHEN_PENALTY = 50;
 const SHORT_LINE_RATIO = 0.6;
 const RIVER_THRESHOLD = 1.5;
 const INFEASIBLE_SPACE_RATIO = 0.4;
@@ -11,16 +13,21 @@ const TIGHT_SPACE_RATIO = 0.65;
 
 export interface BreakOptions {
 	normalSpaceWidth: number;
+	hyphenWidth: number;
 }
+
+type BreakCandidateKind = "start" | "space" | "soft-hyphen" | "end";
 
 interface BreakCandidate {
 	segIndex: number;
+	kind: BreakCandidateKind;
 }
 
 interface LineStats {
 	wordWidth: number;
 	spaceCount: number;
 	naturalWidth: number;
+	trailingHyphen: boolean;
 }
 
 function isSpaceText(text: string): boolean {
@@ -34,14 +41,17 @@ function getLineStats(
 	fromCandidate: number,
 	toCandidate: number,
 	normalSpaceWidth: number,
+	hyphenWidth: number,
 ): LineStats {
 	const from = breakCandidates[fromCandidate]!.segIndex;
 	const to = breakCandidates[toCandidate]!.segIndex;
+	const trailingHyphen = breakCandidates[toCandidate]!.kind === "soft-hyphen";
 
 	let wordWidth = 0;
 	let spaceCount = 0;
 	for (let segIndex = from; segIndex < to; segIndex++) {
 		const text = segments[segIndex]!;
+		if (text === SOFT_HYPHEN) continue;
 		if (isSpaceText(text)) {
 			spaceCount++;
 		} else {
@@ -53,10 +63,15 @@ function getLineStats(
 		spaceCount--;
 	}
 
+	if (trailingHyphen) {
+		wordWidth += hyphenWidth;
+	}
+
 	return {
 		wordWidth,
 		spaceCount,
 		naturalWidth: wordWidth + spaceCount * normalSpaceWidth,
+		trailingHyphen,
 	};
 }
 
@@ -95,7 +110,9 @@ function lineBadness(
 		? 3000 + (tightThreshold - justifiedSpace) * (tightThreshold - justifiedSpace) * 10000
 		: 0;
 
-	return badness + riverPenalty + tightPenalty;
+	const hyphenCost = stats.trailingHyphen ? HYPHEN_PENALTY : 0;
+
+	return badness + riverPenalty + tightPenalty + hyphenCost;
 }
 
 export function breakParagraph(
@@ -110,14 +127,20 @@ export function breakParagraph(
 
 	if (segmentCount === 0) return [];
 
-	const breakCandidates: BreakCandidate[] = [{ segIndex: 0 }];
+	const breakCandidates: BreakCandidate[] = [{ segIndex: 0, kind: "start" }];
 	for (let segIndex = 0; segIndex < segmentCount; segIndex++) {
 		const text = segments[segIndex]!;
+		if (text === SOFT_HYPHEN) {
+			if (segIndex + 1 < segmentCount) {
+				breakCandidates.push({ segIndex: segIndex + 1, kind: "soft-hyphen" });
+			}
+			continue;
+		}
 		if (isSpaceText(text) && segIndex + 1 < segmentCount) {
-			breakCandidates.push({ segIndex: segIndex + 1 });
+			breakCandidates.push({ segIndex: segIndex + 1, kind: "space" });
 		}
 	}
-	breakCandidates.push({ segIndex: segmentCount });
+	breakCandidates.push({ segIndex: segmentCount, kind: "end" });
 
 	const candidateCount = breakCandidates.length;
 	const dp: number[] = new Array(candidateCount).fill(Infinity);
@@ -125,7 +148,7 @@ export function breakParagraph(
 	dp[0] = 0;
 
 	for (let toCandidate = 1; toCandidate < candidateCount; toCandidate++) {
-		const isLastLine = toCandidate === candidateCount - 1;
+		const isLastLine = breakCandidates[toCandidate]!.kind === "end";
 
 		for (let fromCandidate = toCandidate - 1; fromCandidate >= 0; fromCandidate--) {
 			if (dp[fromCandidate] === Infinity) continue;
@@ -136,6 +159,7 @@ export function breakParagraph(
 				fromCandidate,
 				toCandidate,
 				opts.normalSpaceWidth,
+				opts.hyphenWidth,
 			);
 
 			if (stats.naturalWidth > maxWidth * 2) break;
@@ -148,19 +172,18 @@ export function breakParagraph(
 		}
 	}
 
-	// If DP couldn't find any valid path (e.g. single oversized word), use greedy fallback
 	if (dp[candidateCount - 1] === Infinity) {
 		const fallbackLines: PositionedLine[] = [];
 		let from = 0;
 		for (let to = 1; to < candidateCount; to++) {
 			fallbackLines.push(
-				buildLine(prepared, verseMap, breakCandidates, from, to, maxWidth, opts.normalSpaceWidth, to === candidateCount - 1),
+				buildLine(prepared, verseMap, breakCandidates, from, to, maxWidth, opts, to === candidateCount - 1),
 			);
 			from = to;
 		}
 		if (fallbackLines.length === 0 && candidateCount >= 2) {
 			fallbackLines.push(
-				buildLine(prepared, verseMap, breakCandidates, 0, candidateCount - 1, maxWidth, opts.normalSpaceWidth, true),
+				buildLine(prepared, verseMap, breakCandidates, 0, candidateCount - 1, maxWidth, opts, true),
 			);
 		}
 		return fallbackLines;
@@ -191,7 +214,7 @@ export function breakParagraph(
 			fromCandidate,
 			toCandidate,
 			maxWidth,
-			opts.normalSpaceWidth,
+			opts,
 			isLast,
 		);
 		lines.push(line);
@@ -208,11 +231,12 @@ function buildLine(
 	fromCandidate: number,
 	toCandidate: number,
 	maxWidth: number,
-	normalSpaceWidth: number,
+	opts: BreakOptions,
 	isLast: boolean,
 ): PositionedLine {
 	const from = breakCandidates[fromCandidate]!.segIndex;
 	const to = breakCandidates[toCandidate]!.segIndex;
+	const trailingHyphen = breakCandidates[toCandidate]!.kind === "soft-hyphen" && !isLast;
 
 	const lineSegments: LineSegment[] = [];
 	let charOffset = 0;
@@ -225,6 +249,12 @@ function buildLine(
 	for (let segIndex = from; segIndex < to; segIndex++) {
 		const text = prepared.segments[segIndex]!;
 		const width = prepared.widths[segIndex]!;
+
+		if (text === SOFT_HYPHEN) {
+			charOffset += text.length;
+			continue;
+		}
+
 		const vid = getVerseIdAtOffset(verseMap, charOffset);
 
 		if (isSpaceText(text)) {
@@ -235,6 +265,10 @@ function buildLine(
 		}
 
 		charOffset += text.length;
+	}
+
+	if (trailingHyphen) {
+		lineSegments.push({ kind: "text", text: "-", width: opts.hyphenWidth });
 	}
 
 	// Trim trailing spaces
@@ -251,7 +285,7 @@ function buildLine(
 			wordWidth += seg.width;
 		}
 	}
-	const naturalWidth = wordWidth + spaceCount * normalSpaceWidth;
+	const naturalWidth = wordWidth + spaceCount * opts.normalSpaceWidth;
 
 	let spacing: LineSpacing;
 	if (isLast) {
@@ -260,10 +294,10 @@ function buildLine(
 		spacing = { kind: "ragged" };
 	} else {
 		const rawJustifiedSpace = (maxWidth - wordWidth) / spaceCount;
-		if (rawJustifiedSpace < normalSpaceWidth * OVERFLOW_SPACE_RATIO) {
+		if (rawJustifiedSpace < opts.normalSpaceWidth * OVERFLOW_SPACE_RATIO) {
 			spacing = { kind: "overflow" };
 		} else {
-			const wordSpacingPx = rawJustifiedSpace - normalSpaceWidth;
+			const wordSpacingPx = rawJustifiedSpace - opts.normalSpaceWidth;
 			spacing = { kind: "justified", wordSpacingPx };
 		}
 	}

--- a/utils/typeset/knuthPlass.ts
+++ b/utils/typeset/knuthPlass.ts
@@ -219,6 +219,7 @@ function buildLine(
 	for (let i = 0; i < from; i++) {
 		charOffset += prepared.segments[i]!.length;
 	}
+	const charStartOffset = charOffset;
 
 	const verseIdsSet = new Set<string>();
 	for (let segIndex = from; segIndex < to; segIndex++) {
@@ -243,16 +244,14 @@ function buildLine(
 
 	let wordWidth = 0;
 	let spaceCount = 0;
-	let naturalWidth = 0;
 	for (const seg of lineSegments) {
-		naturalWidth += seg.kind === "space" ? seg.width : seg.width;
 		if (seg.kind === "space") {
 			spaceCount++;
 		} else {
 			wordWidth += seg.width;
 		}
 	}
-	naturalWidth = wordWidth + spaceCount * normalSpaceWidth;
+	const naturalWidth = wordWidth + spaceCount * normalSpaceWidth;
 
 	let spacing: LineSpacing;
 	if (isLast) {
@@ -277,6 +276,7 @@ function buildLine(
 		wordWidth,
 		spaceCount,
 		naturalWidth,
+		charStartOffset,
 	};
 }
 

--- a/utils/typeset/paragraphBuilder.test.ts
+++ b/utils/typeset/paragraphBuilder.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { buildParagraphRuns, getVerseIdAtOffset } from "./paragraphBuilder";
+import type { Chapter, Verse } from "../../types/bible";
+
+function makeVerse(verse: string, text: string, opts?: { paragraph?: boolean; poetry?: boolean }): Verse {
+	return { verse, text, ...opts };
+}
+
+function makeChapter(chapter: string, verses: Verse[], title?: string): Chapter {
+	return { chapter, verses, title };
+}
+
+describe("paragraphBuilder", () => {
+	describe("buildParagraphRuns", () => {
+		it("groups consecutive prose verses into a single paragraph run", () => {
+			const ch = makeChapter("1", [
+				makeVerse("1", "In the beginning God created the heaven and the earth."),
+				makeVerse("2", "And the earth was without form, and void."),
+			]);
+
+			const runs = buildParagraphRuns(ch, false);
+			expect(runs).toHaveLength(1);
+			expect(runs[0]!.kind).toBe("paragraph");
+			if (runs[0]!.kind === "paragraph") {
+				expect(runs[0]!.input.verseMap).toHaveLength(2);
+				expect(runs[0]!.input.text).toContain("In the beginning");
+				expect(runs[0]!.input.text).toContain("And the earth");
+			}
+		});
+
+		it("breaks on paragraph markers", () => {
+			const ch = makeChapter("1", [
+				makeVerse("1", "First verse."),
+				makeVerse("2", "Second verse."),
+				makeVerse("3", "Third verse.", { paragraph: true }),
+				makeVerse("4", "Fourth verse."),
+			]);
+
+			const runs = buildParagraphRuns(ch, false);
+			expect(runs).toHaveLength(2);
+			expect(runs[0]!.kind).toBe("paragraph");
+			expect(runs[1]!.kind).toBe("paragraph");
+			if (runs[0]!.kind === "paragraph" && runs[1]!.kind === "paragraph") {
+				expect(runs[0]!.input.verseMap).toHaveLength(2);
+				expect(runs[1]!.input.verseMap).toHaveLength(2);
+			}
+		});
+
+		it("separates poetry verses into individual runs", () => {
+			const ch = makeChapter("1", [
+				makeVerse("1", "Prose verse."),
+				makeVerse("2", "Poetry line.", { poetry: true }),
+				makeVerse("3", "More prose."),
+			]);
+
+			const runs = buildParagraphRuns(ch, false);
+			expect(runs).toHaveLength(3);
+			expect(runs[0]!.kind).toBe("paragraph");
+			expect(runs[1]!.kind).toBe("poetry");
+			expect(runs[2]!.kind).toBe("paragraph");
+		});
+
+		it("handles psalm titles", () => {
+			const ch = makeChapter("3", [
+				makeVerse("1", "Lord, how are they increased.", { poetry: true }),
+			], "A Psalm of David");
+
+			const runs = buildParagraphRuns(ch, false);
+			expect(runs[0]!.kind).toBe("psalmTitle");
+			if (runs[0]!.kind === "psalmTitle") {
+				expect(runs[0]!.text).toBe("A Psalm of David");
+			}
+		});
+
+		it("drops first character for single-chapter book drop cap", () => {
+			const ch = makeChapter("1", [
+				makeVerse("1", "The elder unto the elect lady."),
+			]);
+
+			const runs = buildParagraphRuns(ch, true);
+			expect(runs).toHaveLength(1);
+			if (runs[0]!.kind === "paragraph") {
+				expect(runs[0]!.input.firstCharDropCap).toBe(true);
+				expect(runs[0]!.input.text).toBe("he elder unto the elect lady.");
+			}
+		});
+
+		it("does not drop first char for multi-chapter book", () => {
+			const ch = makeChapter("1", [
+				makeVerse("1", "In the beginning."),
+			]);
+
+			const runs = buildParagraphRuns(ch, false);
+			if (runs[0]!.kind === "paragraph") {
+				expect(runs[0]!.input.firstCharDropCap).toBe(false);
+				expect(runs[0]!.input.text).toBe("In the beginning.");
+			}
+		});
+
+		it("builds verse numbers map correctly", () => {
+			const ch = makeChapter("5", [
+				makeVerse("1", "First."),
+				makeVerse("2", "Second."),
+			]);
+
+			const runs = buildParagraphRuns(ch, false);
+			if (runs[0]!.kind === "paragraph") {
+				expect(runs[0]!.verseNumbers.get("5:1")).toBe("1");
+				expect(runs[0]!.verseNumbers.get("5:2")).toBe("2");
+			}
+		});
+
+		it("computes correct verse map offsets", () => {
+			const ch = makeChapter("1", [
+				makeVerse("1", "Hello world."),
+				makeVerse("2", "Goodbye."),
+			]);
+
+			const runs = buildParagraphRuns(ch, false);
+			if (runs[0]!.kind === "paragraph") {
+				const { verseMap, text } = runs[0]!.input;
+				expect(text.slice(verseMap[0]!.start, verseMap[0]!.end)).toBe("Hello world.");
+				expect(text.slice(verseMap[1]!.start, verseMap[1]!.end)).toBe("Goodbye.");
+			}
+		});
+	});
+
+	describe("getVerseIdAtOffset", () => {
+		it("returns correct verse id for offsets within ranges", () => {
+			const map = [
+				{ start: 0, end: 10, verseId: "1:1" },
+				{ start: 11, end: 20, verseId: "1:2" },
+			];
+			expect(getVerseIdAtOffset(map, 0)).toBe("1:1");
+			expect(getVerseIdAtOffset(map, 5)).toBe("1:1");
+			expect(getVerseIdAtOffset(map, 11)).toBe("1:2");
+		});
+
+		it("returns last verse id for out-of-range offset", () => {
+			const map = [
+				{ start: 0, end: 10, verseId: "1:1" },
+			];
+			expect(getVerseIdAtOffset(map, 99)).toBe("1:1");
+		});
+	});
+});

--- a/utils/typeset/paragraphBuilder.ts
+++ b/utils/typeset/paragraphBuilder.ts
@@ -1,0 +1,109 @@
+import type { Chapter, Verse } from "../../types/bible";
+import type { ParagraphInput, VerseMapEntry, Run } from "./types";
+
+export function buildParagraphRuns(
+	chapter: Chapter,
+	isSingleChapterBook: boolean,
+): Run[] {
+	const runs: Run[] = [];
+	const verses = chapter.verses;
+
+	if (chapter.title) {
+		runs.push({ kind: "psalmTitle", text: chapter.title });
+	}
+
+	let currentParagraphVerses: Verse[] = [];
+	let currentParagraphStart = 0;
+
+	const flushParagraph = () => {
+		if (currentParagraphVerses.length === 0) return;
+
+		const isFirstRun = runs.length === 0 || (runs.length === 1 && runs[0]!.kind === "psalmTitle");
+		const firstCharDropCap = isFirstRun && currentParagraphStart === 0 && isSingleChapterBook;
+
+		const input = buildParagraphInput(
+			currentParagraphVerses,
+			chapter.chapter,
+			firstCharDropCap,
+		);
+
+		const verseNumbers = new Map<string, string>();
+		for (const v of currentParagraphVerses) {
+			const id = `${chapter.chapter}:${v.verse}`;
+			verseNumbers.set(id, v.verse);
+		}
+
+		runs.push({ kind: "paragraph", input, verseNumbers });
+		currentParagraphVerses = [];
+	};
+
+	for (let i = 0; i < verses.length; i++) {
+		const verse = verses[i]!;
+
+		if (verse.poetry) {
+			flushParagraph();
+			runs.push({
+				kind: "poetry",
+				verseId: `${chapter.chapter}:${verse.verse}`,
+				verseNumber: verse.verse,
+				text: verse.text,
+				isNewParagraph: !!verse.paragraph,
+			});
+			currentParagraphStart = i + 1;
+			continue;
+		}
+
+		if (verse.paragraph && currentParagraphVerses.length > 0) {
+			flushParagraph();
+			currentParagraphStart = i;
+		}
+
+		currentParagraphVerses.push(verse);
+	}
+
+	flushParagraph();
+	return runs;
+}
+
+function buildParagraphInput(
+	verses: Verse[],
+	chapterNum: string,
+	firstCharDropCap: boolean,
+): ParagraphInput {
+	let text = "";
+	const verseMap: VerseMapEntry[] = [];
+
+	for (let i = 0; i < verses.length; i++) {
+		const verse = verses[i]!;
+		const verseId = `${chapterNum}:${verse.verse}`;
+
+		if (i > 0) {
+			text += " ";
+		}
+
+		let verseText = verse.text;
+		if (firstCharDropCap && i === 0) {
+			verseText = verseText.slice(1);
+		}
+
+		const start = text.length;
+		text += verseText;
+		const end = text.length;
+
+		verseMap.push({ start, end, verseId });
+	}
+
+	return { text, verseMap, firstCharDropCap };
+}
+
+export function getVerseIdAtOffset(
+	verseMap: VerseMapEntry[],
+	offset: number,
+): string {
+	for (const entry of verseMap) {
+		if (offset >= entry.start && offset < entry.end) {
+			return entry.verseId;
+		}
+	}
+	return verseMap[verseMap.length - 1]?.verseId ?? "";
+}

--- a/utils/typeset/pretextAdapter.ts
+++ b/utils/typeset/pretextAdapter.ts
@@ -1,0 +1,41 @@
+import type { PreparedTextWithSegments } from "@chenglou/pretext";
+
+type PretextModule = typeof import("@chenglou/pretext");
+
+let cachedModule: PretextModule | null = null;
+let loadPromise: Promise<PretextModule> | null = null;
+
+export async function loadPretext(): Promise<PretextModule> {
+	if (cachedModule) return cachedModule;
+	if (!loadPromise) {
+		loadPromise = import("@chenglou/pretext").then((mod) => {
+			cachedModule = mod;
+			return mod;
+		});
+	}
+	return loadPromise;
+}
+
+export async function awaitFont(fontShorthand: string): Promise<boolean> {
+	try {
+		await document.fonts.load(fontShorthand);
+		return document.fonts.check(fontShorthand);
+	} catch {
+		return false;
+	}
+}
+
+export function readContainerFont(el: HTMLElement): string {
+	const style = getComputedStyle(el);
+	return style.font;
+}
+
+export function measureSpaceWidth(font: string): number {
+	const canvas = document.createElement("canvas");
+	const ctx = canvas.getContext("2d");
+	if (!ctx) return 4;
+	ctx.font = font;
+	return ctx.measureText(" ").width;
+}
+
+export type { PreparedTextWithSegments, PretextModule };

--- a/utils/typeset/pretextAdapter.ts
+++ b/utils/typeset/pretextAdapter.ts
@@ -38,4 +38,12 @@ export function measureSpaceWidth(font: string): number {
 	return ctx.measureText(" ").width;
 }
 
+export function measureHyphenWidth(font: string): number {
+	const canvas = document.createElement("canvas");
+	const ctx = canvas.getContext("2d");
+	if (!ctx) return 4;
+	ctx.font = font;
+	return ctx.measureText("-").width;
+}
+
 export type { PreparedTextWithSegments, PretextModule };

--- a/utils/typeset/renderLines.tsx
+++ b/utils/typeset/renderLines.tsx
@@ -25,7 +25,6 @@ interface RenderLinesProps {
 interface VerseChunk {
 	verseId: string;
 	segments: LineSegment[];
-	isFirstOccurrence: boolean;
 }
 
 export function renderPositionedLines({
@@ -43,13 +42,13 @@ export function renderPositionedLines({
 				? `${line.spacing.wordSpacingPx}px`
 				: undefined;
 
-		const chunks = groupSegmentsByVerse(line, verseMap, paragraphText, lineIdx);
+		const chunks = groupSegmentsByVerse(line, verseMap);
 		const lineKey = `ptl-${lineIdx}`;
 
 		return (
 			<div
 				key={lineKey}
-				className={`${styles.ptLine} ${line.isLast ? styles.ptLineLast : ""}`}
+				className={`${styles.ptLine}${line.isLast ? ` ${styles.ptLineLast}` : ""}`}
 				style={wordSpacing ? { wordSpacing } : undefined}
 			>
 				{chunks.map((chunk, chunkIdx) => {
@@ -57,36 +56,28 @@ export function renderPositionedLines({
 					if (isFirstGlobal) seenVerseIds.add(chunk.verseId);
 
 					const verseNum = verseNumbers.get(chunk.verseId);
-					const chunkText = chunk.segments
-						.filter((s) => s.kind === "text")
-						.map((s) => (s as { kind: "text"; text: string; width: number }).text)
-						.join(" ");
 
 					const isHighlighted = handlers.highlightVerse === chunk.verseId;
 					const isReading = handlers.readingVerse === chunk.verseId;
-					const [, chVs] = chunk.verseId.split(":");
 					const isSelected =
-						handlers.selectedVerse &&
+						handlers.selectedVerse != null &&
 						chunk.verseId ===
 							`${handlers.selectedVerse.chapter}:${handlers.selectedVerse.verse}`;
 
 					const verseClasses = [
 						styles.verse,
 						"verse",
-						isHighlighted ? styles.selected : "",
-						isReading ? styles.reading : "",
-						isSelected ? styles.selected : "",
+						isHighlighted && styles.selected,
+						isReading && styles.reading,
+						isSelected && styles.selected,
 					]
 						.filter(Boolean)
 						.join(" ");
 
-					const fullVerseText =
-						verseMap.find((v) => v.verseId === chunk.verseId)
-							? paragraphText.slice(
-									verseMap.find((v) => v.verseId === chunk.verseId)!.start,
-									verseMap.find((v) => v.verseId === chunk.verseId)!.end,
-								)
-							: chunkText;
+					const entry = verseMap.find((v) => v.verseId === chunk.verseId);
+					const fullVerseText = entry
+						? paragraphText.slice(entry.start, entry.end)
+						: "";
 
 					return (
 						<span key={`${lineKey}-${chunkIdx}`}>
@@ -133,19 +124,12 @@ function renderChunkContent(segments: LineSegment[]): string {
 function groupSegmentsByVerse(
 	line: PositionedLine,
 	verseMap: VerseMapEntry[],
-	fullText: string,
-	lineIdx: number,
 ): VerseChunk[] {
 	const chunks: VerseChunk[] = [];
 	if (line.segments.length === 0) return chunks;
 
-	// We need to find the character offset for this line's segments in the full text
-	// Reconstruct offset by walking through segments
 	let currentChunk: VerseChunk | null = null;
-
-	// Use line's verseIds as a fallback, but do segment-level assignment
-	// by tracking position in the text
-	let textPosition = findLineTextStart(line, fullText);
+	let textPosition = line.charStartOffset;
 
 	for (const seg of line.segments) {
 		const verseId = getVerseIdAtOffset(verseMap, textPosition);
@@ -155,7 +139,6 @@ function groupSegmentsByVerse(
 			currentChunk = {
 				verseId,
 				segments: [seg],
-				isFirstOccurrence: false,
 			};
 		} else {
 			currentChunk.segments.push(seg);
@@ -164,38 +147,10 @@ function groupSegmentsByVerse(
 		if (seg.kind === "text") {
 			textPosition += seg.text.length;
 		} else {
-			textPosition += 1; // space
+			textPosition += 1;
 		}
 	}
 
 	if (currentChunk) chunks.push(currentChunk);
 	return chunks;
-}
-
-function findLineTextStart(line: PositionedLine, fullText: string): number {
-	// Build the line's text content (excluding spaces at boundaries)
-	const lineTextParts: string[] = [];
-	for (const seg of line.segments) {
-		if (seg.kind === "text") {
-			lineTextParts.push(seg.text);
-			break; // just need first word to find position
-		}
-	}
-
-	if (lineTextParts.length === 0) return 0;
-
-	const firstWord = lineTextParts[0]!;
-	// Find this word in the full text - search from each possible position
-	let idx = 0;
-	while (idx < fullText.length) {
-		const found = fullText.indexOf(firstWord, idx);
-		if (found === -1) return 0;
-		// Verify it's at a word boundary (start of text or preceded by space)
-		if (found === 0 || fullText[found - 1] === " ") {
-			return found;
-		}
-		idx = found + 1;
-	}
-
-	return 0;
 }

--- a/utils/typeset/renderLines.tsx
+++ b/utils/typeset/renderLines.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { type ReactNode } from "react";
+import type { PositionedLine, LineSegment } from "./types";
+import styles from "../../components/Reader/Reader.module.css";
+import { getVerseIdAtOffset } from "./paragraphBuilder";
+import type { VerseMapEntry } from "./types";
+
+interface VerseHandlers {
+	onPointerDown: (e: React.PointerEvent) => void;
+	onPointerUp: (e: React.PointerEvent, verseId: string, text: string) => void;
+	highlightVerse: string | null;
+	readingVerse: string | null;
+	selectedVerse: { chapter: string; verse: string } | null;
+}
+
+interface RenderLinesProps {
+	lines: PositionedLine[];
+	verseMap: VerseMapEntry[];
+	verseNumbers: Map<string, string>;
+	handlers: VerseHandlers;
+	paragraphText: string;
+}
+
+interface VerseChunk {
+	verseId: string;
+	segments: LineSegment[];
+	isFirstOccurrence: boolean;
+}
+
+export function renderPositionedLines({
+	lines,
+	verseMap,
+	verseNumbers,
+	handlers,
+	paragraphText,
+}: RenderLinesProps): ReactNode {
+	const seenVerseIds = new Set<string>();
+
+	return lines.map((line, lineIdx) => {
+		const wordSpacing =
+			line.spacing.kind === "justified"
+				? `${line.spacing.wordSpacingPx}px`
+				: undefined;
+
+		const chunks = groupSegmentsByVerse(line, verseMap, paragraphText, lineIdx);
+		const lineKey = `ptl-${lineIdx}`;
+
+		return (
+			<div
+				key={lineKey}
+				className={`${styles.ptLine} ${line.isLast ? styles.ptLineLast : ""}`}
+				style={wordSpacing ? { wordSpacing } : undefined}
+			>
+				{chunks.map((chunk, chunkIdx) => {
+					const isFirstGlobal = !seenVerseIds.has(chunk.verseId);
+					if (isFirstGlobal) seenVerseIds.add(chunk.verseId);
+
+					const verseNum = verseNumbers.get(chunk.verseId);
+					const chunkText = chunk.segments
+						.filter((s) => s.kind === "text")
+						.map((s) => (s as { kind: "text"; text: string; width: number }).text)
+						.join(" ");
+
+					const isHighlighted = handlers.highlightVerse === chunk.verseId;
+					const isReading = handlers.readingVerse === chunk.verseId;
+					const [, chVs] = chunk.verseId.split(":");
+					const isSelected =
+						handlers.selectedVerse &&
+						chunk.verseId ===
+							`${handlers.selectedVerse.chapter}:${handlers.selectedVerse.verse}`;
+
+					const verseClasses = [
+						styles.verse,
+						"verse",
+						isHighlighted ? styles.selected : "",
+						isReading ? styles.reading : "",
+						isSelected ? styles.selected : "",
+					]
+						.filter(Boolean)
+						.join(" ");
+
+					const fullVerseText =
+						verseMap.find((v) => v.verseId === chunk.verseId)
+							? paragraphText.slice(
+									verseMap.find((v) => v.verseId === chunk.verseId)!.start,
+									verseMap.find((v) => v.verseId === chunk.verseId)!.end,
+								)
+							: chunkText;
+
+					return (
+						<span key={`${lineKey}-${chunkIdx}`}>
+							{isFirstGlobal && (
+								<span
+									id={chunk.verseId}
+									className={styles.verseAnchor}
+									aria-hidden="true"
+								/>
+							)}
+							<span
+								data-verse-id={chunk.verseId}
+								className={verseClasses}
+								onPointerDown={handlers.onPointerDown}
+								onPointerUp={(e) =>
+									handlers.onPointerUp(e, chunk.verseId, fullVerseText)
+								}
+							>
+								{isFirstGlobal && verseNum && (
+									<sup>{verseNum}&nbsp;</sup>
+								)}
+								{renderChunkContent(chunk.segments)}
+							</span>
+						</span>
+					);
+				})}
+			</div>
+		);
+	});
+}
+
+function renderChunkContent(segments: LineSegment[]): string {
+	const parts: string[] = [];
+	for (const seg of segments) {
+		if (seg.kind === "text") {
+			parts.push(seg.text);
+		} else {
+			parts.push(" ");
+		}
+	}
+	return parts.join("");
+}
+
+function groupSegmentsByVerse(
+	line: PositionedLine,
+	verseMap: VerseMapEntry[],
+	fullText: string,
+	lineIdx: number,
+): VerseChunk[] {
+	const chunks: VerseChunk[] = [];
+	if (line.segments.length === 0) return chunks;
+
+	// We need to find the character offset for this line's segments in the full text
+	// Reconstruct offset by walking through segments
+	let currentChunk: VerseChunk | null = null;
+
+	// Use line's verseIds as a fallback, but do segment-level assignment
+	// by tracking position in the text
+	let textPosition = findLineTextStart(line, fullText);
+
+	for (const seg of line.segments) {
+		const verseId = getVerseIdAtOffset(verseMap, textPosition);
+
+		if (!currentChunk || currentChunk.verseId !== verseId) {
+			if (currentChunk) chunks.push(currentChunk);
+			currentChunk = {
+				verseId,
+				segments: [seg],
+				isFirstOccurrence: false,
+			};
+		} else {
+			currentChunk.segments.push(seg);
+		}
+
+		if (seg.kind === "text") {
+			textPosition += seg.text.length;
+		} else {
+			textPosition += 1; // space
+		}
+	}
+
+	if (currentChunk) chunks.push(currentChunk);
+	return chunks;
+}
+
+function findLineTextStart(line: PositionedLine, fullText: string): number {
+	// Build the line's text content (excluding spaces at boundaries)
+	const lineTextParts: string[] = [];
+	for (const seg of line.segments) {
+		if (seg.kind === "text") {
+			lineTextParts.push(seg.text);
+			break; // just need first word to find position
+		}
+	}
+
+	if (lineTextParts.length === 0) return 0;
+
+	const firstWord = lineTextParts[0]!;
+	// Find this word in the full text - search from each possible position
+	let idx = 0;
+	while (idx < fullText.length) {
+		const found = fullText.indexOf(firstWord, idx);
+		if (found === -1) return 0;
+		// Verify it's at a word boundary (start of text or preceded by space)
+		if (found === 0 || fullText[found - 1] === " ") {
+			return found;
+		}
+		idx = found + 1;
+	}
+
+	return 0;
+}

--- a/utils/typeset/renderLines.tsx
+++ b/utils/typeset/renderLines.tsx
@@ -48,7 +48,7 @@ export function renderPositionedLines({
 		return (
 			<div
 				key={lineKey}
-				className={`${styles.ptLine}${line.isLast ? ` ${styles.ptLineLast}` : ""}`}
+				className={styles.ptLine}
 				style={wordSpacing ? { wordSpacing } : undefined}
 			>
 				{chunks.map((chunk, chunkIdx) => {

--- a/utils/typeset/types.ts
+++ b/utils/typeset/types.ts
@@ -1,0 +1,35 @@
+export interface VerseMapEntry {
+	start: number;
+	end: number;
+	verseId: string;
+}
+
+export interface ParagraphInput {
+	text: string;
+	verseMap: VerseMapEntry[];
+	firstCharDropCap: boolean;
+}
+
+export type Run =
+	| { kind: "paragraph"; input: ParagraphInput; verseNumbers: Map<string, string> }
+	| { kind: "poetry"; verseId: string; verseNumber: string; text: string; isNewParagraph: boolean }
+	| { kind: "psalmTitle"; text: string };
+
+export type LineSegment =
+	| { kind: "text"; text: string; width: number }
+	| { kind: "space"; width: number };
+
+export type LineSpacing =
+	| { kind: "ragged" }
+	| { kind: "overflow" }
+	| { kind: "justified"; wordSpacingPx: number };
+
+export interface PositionedLine {
+	segments: LineSegment[];
+	verseIds: string[];
+	spacing: LineSpacing;
+	isLast: boolean;
+	wordWidth: number;
+	spaceCount: number;
+	naturalWidth: number;
+}

--- a/utils/typeset/types.ts
+++ b/utils/typeset/types.ts
@@ -32,4 +32,5 @@ export interface PositionedLine {
 	wordWidth: number;
 	spaceCount: number;
 	naturalWidth: number;
+	charStartOffset: number;
 }

--- a/utils/useTypeset.ts
+++ b/utils/useTypeset.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import type { ParagraphInput, PositionedLine } from "./typeset/types";
 import type { PreparedTextWithSegments } from "@chenglou/pretext";
+import type { BreakOptions } from "./typeset/knuthPlass";
 
 interface UseTypesetResult {
 	lines: PositionedLine[] | null;
@@ -21,15 +22,13 @@ export function useTypeset(
 	const [error, setError] = useState<Error | null>(null);
 	const preparedRef = useRef<PreparedTextWithSegments | null>(null);
 	const widthRef = useRef<number>(0);
-	const fontRef = useRef<string>("");
-	const normalSpaceWidthRef = useRef<number>(0);
+	const optsRef = useRef<BreakOptions>({ normalSpaceWidth: 4, hyphenWidth: 4 });
 
-	const rebreak = useCallback((prepared: PreparedTextWithSegments, width: number, normalSpaceWidth: number, verseMap: ParagraphInput["verseMap"]) => {
+	const rebreak = useCallback((prepared: PreparedTextWithSegments, width: number, opts: BreakOptions, verseMap: ParagraphInput["verseMap"]) => {
 		if (width <= 0) return;
 		import("./typeset/knuthPlass").then(({ breakParagraph }) => {
 			try {
-				// Shrink by 0.5px to avoid sub-pixel overflow
-				const result = breakParagraph(prepared, verseMap, width - 0.5, { normalSpaceWidth });
+				const result = breakParagraph(prepared, verseMap, width - 0.5, opts);
 				setLines(result);
 				setError(null);
 			} catch (err) {
@@ -54,14 +53,16 @@ export function useTypeset(
 
 				const font = getComputedStyle(containerEl).font;
 				if (!font || cancelled) return;
-				fontRef.current = font;
 
-				const cacheKey = `${input.text}|${font}`;
+				const { hyphenateText } = await import("./typeset/hyphenate");
+				const hyphenatedText = hyphenateText(input.text);
+
+				const cacheKey = `${hyphenatedText}|${font}`;
 				let prepared = preparedCache.get(cacheKey);
 
 				if (!prepared) {
 					const pretext = await import("@chenglou/pretext");
-					prepared = pretext.prepareWithSegments(input.text, font);
+					prepared = pretext.prepareWithSegments(hyphenatedText, font);
 					if (preparedCache.size >= MAX_CACHE_SIZE) {
 						const firstKey = preparedCache.keys().next().value;
 						if (firstKey !== undefined) preparedCache.delete(firstKey);
@@ -72,12 +73,15 @@ export function useTypeset(
 				if (cancelled) return;
 				preparedRef.current = prepared;
 
-				const { measureSpaceWidth } = await import("./typeset/pretextAdapter");
-				normalSpaceWidthRef.current = measureSpaceWidth(font);
+				const { measureSpaceWidth, measureHyphenWidth } = await import("./typeset/pretextAdapter");
+				optsRef.current = {
+					normalSpaceWidth: measureSpaceWidth(font),
+					hyphenWidth: measureHyphenWidth(font),
+				};
 
 				const width = containerEl.offsetWidth;
 				widthRef.current = width;
-				rebreak(prepared, width, normalSpaceWidthRef.current, input.verseMap);
+				rebreak(prepared, width, optsRef.current, input.verseMap);
 			} catch (err) {
 				if (!cancelled) {
 					console.warn("Typeset failed, falling back to native rendering:", err);
@@ -98,7 +102,7 @@ export function useTypeset(
 			widthRef.current = newWidth;
 
 			if (preparedRef.current && input) {
-				rebreak(preparedRef.current, newWidth, normalSpaceWidthRef.current, input.verseMap);
+				rebreak(preparedRef.current, newWidth, optsRef.current, input.verseMap);
 			}
 		});
 

--- a/utils/useTypeset.ts
+++ b/utils/useTypeset.ts
@@ -93,23 +93,29 @@ export function useTypeset(
 
 		run();
 
+		let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 		const observer = new ResizeObserver((entries) => {
 			if (cancelled) return;
 			const entry = entries[0];
 			if (!entry) return;
 			const newWidth = entry.contentRect.width;
-			if (Math.abs(newWidth - widthRef.current) < 1) return;
-			widthRef.current = newWidth;
+			if (Math.abs(newWidth - widthRef.current) < 5) return;
 
-			if (preparedRef.current && input) {
-				rebreak(preparedRef.current, newWidth, optsRef.current, input.verseMap);
-			}
+			if (debounceTimer) clearTimeout(debounceTimer);
+			debounceTimer = setTimeout(() => {
+				if (cancelled) return;
+				widthRef.current = newWidth;
+				if (preparedRef.current && input) {
+					rebreak(preparedRef.current, newWidth, optsRef.current, input.verseMap);
+				}
+			}, 150);
 		});
 
 		observer.observe(containerEl);
 
 		return () => {
 			cancelled = true;
+			if (debounceTimer) clearTimeout(debounceTimer);
 			observer.disconnect();
 		};
 	}, [enabled, input, containerEl, rebreak]);

--- a/utils/useTypeset.ts
+++ b/utils/useTypeset.ts
@@ -51,7 +51,8 @@ export function useTypeset(
 			try {
 				await document.fonts.ready;
 
-				const font = getComputedStyle(containerEl).font;
+				const cs = getComputedStyle(containerEl);
+				const font = `${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`;
 				if (!font || cancelled) return;
 
 				const { hyphenateText } = await import("./typeset/hyphenate");

--- a/utils/useTypeset.ts
+++ b/utils/useTypeset.ts
@@ -55,7 +55,7 @@ export function useTypeset(
 				if (!font || cancelled) return;
 
 				const { hyphenateText } = await import("./typeset/hyphenate");
-				const hyphenatedText = hyphenateText(input.text);
+				const hyphenatedText = await hyphenateText(input.text);
 
 				const cacheKey = `${hyphenatedText}|${font}`;
 				let prepared = preparedCache.get(cacheKey);

--- a/utils/useTypeset.ts
+++ b/utils/useTypeset.ts
@@ -15,14 +15,15 @@ const preparedCache = new Map<string, PreparedTextWithSegments>();
 
 export function useTypeset(
 	input: ParagraphInput | null,
+	containerWidth: number,
 	containerEl: HTMLElement | null,
 	enabled: boolean,
 ): UseTypesetResult {
 	const [lines, setLines] = useState<PositionedLine[] | null>(null);
 	const [error, setError] = useState<Error | null>(null);
 	const preparedRef = useRef<PreparedTextWithSegments | null>(null);
-	const widthRef = useRef<number>(0);
 	const optsRef = useRef<BreakOptions>({ normalSpaceWidth: 4, hyphenWidth: 4 });
+	const fontRef = useRef<string>("");
 
 	const rebreak = useCallback((prepared: PreparedTextWithSegments, width: number, opts: BreakOptions, verseMap: ParagraphInput["verseMap"]) => {
 		if (width <= 0) return;
@@ -39,7 +40,7 @@ export function useTypeset(
 	}, []);
 
 	useEffect(() => {
-		if (!enabled || !input || !containerEl) {
+		if (!enabled || !input || !containerEl || containerWidth <= 0) {
 			setLines(null);
 			setError(null);
 			return;
@@ -54,6 +55,7 @@ export function useTypeset(
 				const cs = getComputedStyle(containerEl);
 				const font = `${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`;
 				if (!font || cancelled) return;
+				fontRef.current = font;
 
 				const { hyphenateText } = await import("./typeset/hyphenate");
 				const hyphenatedText = await hyphenateText(input.text);
@@ -80,9 +82,7 @@ export function useTypeset(
 					hyphenWidth: measureHyphenWidth(font),
 				};
 
-				const width = containerEl.offsetWidth;
-				widthRef.current = width;
-				rebreak(prepared, width, optsRef.current, input.verseMap);
+				rebreak(prepared, containerWidth, optsRef.current, input.verseMap);
 			} catch (err) {
 				if (!cancelled) {
 					console.warn("Typeset failed, falling back to native rendering:", err);
@@ -94,32 +94,10 @@ export function useTypeset(
 
 		run();
 
-		let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-		const observer = new ResizeObserver((entries) => {
-			if (cancelled) return;
-			const entry = entries[0];
-			if (!entry) return;
-			const newWidth = entry.contentRect.width;
-			if (Math.abs(newWidth - widthRef.current) < 5) return;
-
-			if (debounceTimer) clearTimeout(debounceTimer);
-			debounceTimer = setTimeout(() => {
-				if (cancelled) return;
-				widthRef.current = newWidth;
-				if (preparedRef.current && input) {
-					rebreak(preparedRef.current, newWidth, optsRef.current, input.verseMap);
-				}
-			}, 150);
-		});
-
-		observer.observe(containerEl);
-
 		return () => {
 			cancelled = true;
-			if (debounceTimer) clearTimeout(debounceTimer);
-			observer.disconnect();
 		};
-	}, [enabled, input, containerEl, rebreak]);
+	}, [enabled, input, containerEl, containerWidth, rebreak]);
 
 	return { lines, error };
 }

--- a/utils/useTypeset.ts
+++ b/utils/useTypeset.ts
@@ -9,6 +9,7 @@ interface UseTypesetResult {
 	error: Error | null;
 }
 
+const MAX_CACHE_SIZE = 200;
 const preparedCache = new Map<string, PreparedTextWithSegments>();
 
 export function useTypeset(
@@ -61,6 +62,10 @@ export function useTypeset(
 				if (!prepared) {
 					const pretext = await import("@chenglou/pretext");
 					prepared = pretext.prepareWithSegments(input.text, font);
+					if (preparedCache.size >= MAX_CACHE_SIZE) {
+						const firstKey = preparedCache.keys().next().value;
+						if (firstKey !== undefined) preparedCache.delete(firstKey);
+					}
 					preparedCache.set(cacheKey, prepared);
 				}
 

--- a/utils/useTypeset.ts
+++ b/utils/useTypeset.ts
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import type { ParagraphInput, PositionedLine } from "./typeset/types";
+import type { PreparedTextWithSegments } from "@chenglou/pretext";
+
+interface UseTypesetResult {
+	lines: PositionedLine[] | null;
+	error: Error | null;
+}
+
+const preparedCache = new Map<string, PreparedTextWithSegments>();
+
+export function useTypeset(
+	input: ParagraphInput | null,
+	containerEl: HTMLElement | null,
+	enabled: boolean,
+): UseTypesetResult {
+	const [lines, setLines] = useState<PositionedLine[] | null>(null);
+	const [error, setError] = useState<Error | null>(null);
+	const preparedRef = useRef<PreparedTextWithSegments | null>(null);
+	const widthRef = useRef<number>(0);
+	const fontRef = useRef<string>("");
+	const normalSpaceWidthRef = useRef<number>(0);
+
+	const rebreak = useCallback((prepared: PreparedTextWithSegments, width: number, normalSpaceWidth: number, verseMap: ParagraphInput["verseMap"]) => {
+		if (width <= 0) return;
+		import("./typeset/knuthPlass").then(({ breakParagraph }) => {
+			try {
+				// Shrink by 0.5px to avoid sub-pixel overflow
+				const result = breakParagraph(prepared, verseMap, width - 0.5, { normalSpaceWidth });
+				setLines(result);
+				setError(null);
+			} catch (err) {
+				setError(err instanceof Error ? err : new Error(String(err)));
+				setLines(null);
+			}
+		});
+	}, []);
+
+	useEffect(() => {
+		if (!enabled || !input || !containerEl) {
+			setLines(null);
+			setError(null);
+			return;
+		}
+
+		let cancelled = false;
+
+		const run = async () => {
+			try {
+				await document.fonts.ready;
+
+				const font = getComputedStyle(containerEl).font;
+				if (!font || cancelled) return;
+				fontRef.current = font;
+
+				const cacheKey = `${input.text}|${font}`;
+				let prepared = preparedCache.get(cacheKey);
+
+				if (!prepared) {
+					const pretext = await import("@chenglou/pretext");
+					prepared = pretext.prepareWithSegments(input.text, font);
+					preparedCache.set(cacheKey, prepared);
+				}
+
+				if (cancelled) return;
+				preparedRef.current = prepared;
+
+				const { measureSpaceWidth } = await import("./typeset/pretextAdapter");
+				normalSpaceWidthRef.current = measureSpaceWidth(font);
+
+				const width = containerEl.offsetWidth;
+				widthRef.current = width;
+				rebreak(prepared, width, normalSpaceWidthRef.current, input.verseMap);
+			} catch (err) {
+				if (!cancelled) {
+					console.warn("Typeset failed, falling back to native rendering:", err);
+					setError(err instanceof Error ? err : new Error(String(err)));
+					setLines(null);
+				}
+			}
+		};
+
+		run();
+
+		const observer = new ResizeObserver((entries) => {
+			if (cancelled) return;
+			const entry = entries[0];
+			if (!entry) return;
+			const newWidth = entry.contentRect.width;
+			if (Math.abs(newWidth - widthRef.current) < 1) return;
+			widthRef.current = newWidth;
+
+			if (preparedRef.current && input) {
+				rebreak(preparedRef.current, newWidth, normalSpaceWidthRef.current, input.verseMap);
+			}
+		});
+
+		observer.observe(containerEl);
+
+		return () => {
+			cancelled = true;
+			observer.disconnect();
+		};
+	}, [enabled, input, containerEl, rebreak]);
+
+	return { lines, error };
+}
+
+export function clearTypesetCache(): void {
+	preparedCache.clear();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2021,6 +2021,11 @@ human-signals@^5.0.0:
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz"
   integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
 
+hyphen@^1.14.1:
+  version "1.14.1"
+  resolved "https://registry.npmjs.org/hyphen/-/hyphen-1.14.1.tgz"
+  integrity sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==
+
 ignore@^5.2.0:
   version "5.3.2"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -170,6 +170,11 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
 
+"@chenglou/pretext@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.7.tgz"
+  integrity sha512-FV5hj3fGqpBlzbANUbR+s+6XuNRrghVVyuNs33zdH2SzU7MvK+7GlW6xREjDCreixKbexEn7OEkDgAFeWuu5Hg==
+
 "@esbuild/linux-x64@0.21.5":
   version "0.21.5"
   resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz"


### PR DESCRIPTION
Introduces an experimental "Optimal Justification" toggle in Settings that
uses the Knuth-Plass line-breaking algorithm to produce justified text with
even word spacing and minimal rivers, replacing the browser's default greedy
line-breaking for prose paragraphs.

Architecture:
- utils/typeset/knuthPlass.ts: DP-based paragraph breaker (ported from
  pretext's justification-comparison demo) with badness, river, and
  tightness penalties
- utils/typeset/paragraphBuilder.ts: groups chapter verses into paragraph
  runs (prose → Knuth-Plass, poetry → native passthrough) with verse-offset
  maps for multi-verse paragraph tracking
- utils/typeset/renderLines.tsx: renders PositionedLine[] as DOM divs with
  computed word-spacing and per-verse spans preserving click targets
- utils/useTypeset.ts: React hook with ResizeObserver for responsive reflow
- components/Reader/TypesetChapter: chapter renderer that branches between
  typeset and native verse rendering

Preserves all existing contracts: IntersectionObserver scroll tracking,
red-letter/bookmark CSS injection (selectors extended to target both
native #id and typeset [data-verse-id] spans), verse tap → VerseDetails
drawer, URL hash navigation, text selection, and search highlighting.

Poetry verses and Psalms are excluded from justification (kept as-is with
hanging indent / text-wrap:pretty).

https://claude.ai/code/session_01JaPEVdtBdh1w37ghZ1XW14