### PR TITLE
Make PWA full-bleed so top blur sits behind the Dynamic Island

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -45,7 +45,7 @@ export const metadata = {
 	applicationName: "Holy Bible",
 	appleWebApp: {
 		capable: true,
-		statusBarStyle: "default",
+		statusBarStyle: "black-translucent",
 		title: "Holy Bible",
 	},
 	formatDetection: {

--- a/components/Bookmarks/Bookmarks.module.css
+++ b/components/Bookmarks/Bookmarks.module.css
@@ -29,6 +29,8 @@
 	align-items: center;
 	gap: 16px;
 	padding: 24px;
+	/* Clear the status bar / Dynamic Island in the full-bleed PWA. */
+	padding-top: calc(24px + env(safe-area-inset-top));
 	border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 	flex-shrink: 0;
 	background: white;

--- a/components/Contents/Contents.module.css
+++ b/components/Contents/Contents.module.css
@@ -34,6 +34,8 @@
 
 .bookList {
 	padding: 60px 24px;
+	/* Clear the status bar / Dynamic Island in the full-bleed PWA. */
+	padding-top: calc(60px + env(safe-area-inset-top));
 	overflow: scroll;
 	height: 100%;
 }

--- a/components/Reader/Reader.module.css
+++ b/components/Reader/Reader.module.css
@@ -15,6 +15,9 @@
 	justify-items: center;
 	grid-column: fullbleed;
 	padding: 24px 0;
+	/* Full-bleed PWA (black-translucent status bar): keep resting content clear
+	   of the status bar / Dynamic Island; text dissolves behind it on scroll. */
+	padding-top: calc(24px + env(safe-area-inset-top));
 	padding-bottom: calc(60px + env(safe-area-inset-bottom));
 }
 

--- a/components/search/Search.module.css
+++ b/components/search/Search.module.css
@@ -27,6 +27,8 @@
 	align-items: center;
 	gap: 8px;
 	padding: 18px 24px;
+	/* Clear the status bar / Dynamic Island in the full-bleed PWA. */
+	padding-top: calc(18px + env(safe-area-inset-top));
 	border-bottom: 1px solid rgb(0 0 0 /0.1);
 	background: white;
 	z-index: 99;


### PR DESCRIPTION
## Problem

The top-edge blur effect sat ~1cm **below** the Dynamic Island and couldn't reach it. The cause wasn't the gradient — it was the PWA config. With `statusBarStyle: "default"`, iOS keeps web content below the status bar, so the overlay's `top: 0` is the top of the *content area* (already below the island), not the screen.

## Change

- **`app/layout.tsx`**: `statusBarStyle: "default"` → `"black-translucent"`, making the installed PWA full-bleed so content (and the blur) fills the screen behind the status bar / Dynamic Island. (`viewport-fit=cover` was already set, so the safe-area insets become meaningful.)
- **Safe-area top padding** added to the reading content and the top-anchored overlays so going full-bleed doesn't push their headers under the island:
  - `Reader` content (`padding-top: calc(24px + env(safe-area-inset-top))`)
  - `Search`, `Bookmarks`, `Contents` headers

The blur effect's balance is **unchanged** — it simply reaches the island now because `top: 0` is the true screen top in full-bleed mode.

## Notes / things to verify on device

- **Installed PWA only.** This behaviour applies when launched from the home screen (standalone). In a Safari tab those pixels belong to Safari's chrome and can't be reached.
- **Status bar text colour.** `black-translucent` renders status-bar glyphs (clock/battery) in **white**, which can be low-contrast over the light reading background. Worth a look on device — the blur strip's slight darkening near the top may help, but if it's hard to read we may want to revisit.
- The lower-down gamma-darkening trade-off documented in `TopBlur` still applies; no change here.

https://claude.ai/code/session_019FhqrfmDQexnVbgvMRNPHf